### PR TITLE
Fix issue #232

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ use the `RGBImgPartialObsWrapper`. You can use it as follows:
 import gym
 from gym_minigrid.wrappers import RGBImgPartialObsWrapper, ImgObsWrapper
 
-env = gym.make('MiniGrid-Empty-8x8-v0', new_step_api=True)
+env = gym.make('MiniGrid-Empty-8x8-v0')
 env = RGBImgPartialObsWrapper(env) # Get pixel observations
 env = ImgObsWrapper(env) # Get rid of the 'mission' field
-obs = env.reset() # This now produces an RGB tensor only
+obs, _ = env.reset() # This now produces an RGB tensor only
 ```
 
 ## Design

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -11,7 +11,7 @@ def redraw(window, img):
 
 
 def reset(env, window, seed=None):
-    _ = env.reset(seed=seed)
+    env.reset(seed=seed)
 
     if hasattr(env, "mission"):
         print("Mission: %s" % env.mission)
@@ -101,7 +101,6 @@ if __name__ == "__main__":
 
     env = gym.make(
         args.env,
-        new_step_api=True,
         tile_size=args.tile_size,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    version="1.2.0",
+    version="1.2.1",
     keywords="memory, environment, agent, rl, gym",
     url="https://github.com/Farama-Foundation/gym-minigrid",
     description="Minimalistic gridworld reinforcement learning environments",


### PR DESCRIPTION
## Description
Fixes #232. Latest 1.2.0 MiniGrid release is not backward compatible with gym releases previous to v0.26. Thus every minigrid environment has a hard constraint on using new step API and the option to set the argument `new_step_api=True` in the environments was removed.

#232 bug is due to not having removed the `new_step_api` argument from the `manual_control.py` script. This PR removes it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
