### PR TITLE
Deprecation warning gym_minigrid

### DIFF
--- a/gym_minigrid/__init__.py
+++ b/gym_minigrid/__init__.py
@@ -1,9 +1,18 @@
+from warnings import warn
+
 from gym.envs.registration import register
 
 from gym_minigrid import minigrid, roomgrid, wrappers
 
 
 def register_minigrid_envs():
+
+    # gym_minigrid package deprecated in favor of minigrid
+    warn("The package name gym_minigrid has been deprecated in favor of minigrid. Please uninstall gym_minigrid and install minigrid with `pip install minigrid`. Future releases will be maintained under the new package name minigrid.",
+    DeprecationWarning,
+    stacklevel=2,
+    )
+
     # BlockedUnlockPickup
     # ----------------------------------------
 

--- a/gym_minigrid/__init__.py
+++ b/gym_minigrid/__init__.py
@@ -8,9 +8,10 @@ from gym_minigrid import minigrid, roomgrid, wrappers
 def register_minigrid_envs():
 
     # gym_minigrid package deprecated in favor of minigrid
-    warn("The package name gym_minigrid has been deprecated in favor of minigrid. Please uninstall gym_minigrid and install minigrid with `pip install minigrid`. Future releases will be maintained under the new package name minigrid.",
-    DeprecationWarning,
-    stacklevel=2,
+    warn(
+        "The package name gym_minigrid has been deprecated in favor of minigrid. Please uninstall gym_minigrid and install minigrid with `pip install minigrid`. Future releases will be maintained under the new package name minigrid.",
+        DeprecationWarning,
+        stacklevel=2,
     )
 
     # BlockedUnlockPickup


### PR DESCRIPTION
# Description

This PR adds a warning to legacy package naming `gym_minigrid`. The PyPi package for the MiniGrid repository will now be named `minigrid` and future releases and integration with [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) will be done under this new naming.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
