### PR TITLE
Add `max_steps` argument for all environments

### DIFF
--- a/minigrid/__init__.py
+++ b/minigrid/__init__.py
@@ -25,7 +25,7 @@ def register_minigrid_envs():
     register(
         id="MiniGrid-LavaCrossingS9N2-v0",
         entry_point="minigrid.envs:CrossingEnv",
-        kwargs={"size": 9, "num_crossings": 2}
+        kwargs={"size": 9, "num_crossings": 2},
     )
 
     register(

--- a/minigrid/__init__.py
+++ b/minigrid/__init__.py
@@ -25,7 +25,7 @@ def register_minigrid_envs():
     register(
         id="MiniGrid-LavaCrossingS9N2-v0",
         entry_point="minigrid.envs:CrossingEnv",
-        kwargs={"size": 9, "num_crossings": 2},
+        kwargs={"size": 9, "num_crossings": 2}
     )
 
     register(

--- a/minigrid/envs/babyai/core/roomgrid_level.py
+++ b/minigrid/envs/babyai/core/roomgrid_level.py
@@ -55,8 +55,13 @@ class RoomGridLevel(RoomGrid):
         if max_steps is not None:
             self.fixed_max_steps = True
         else:
-            max_steps = 0 # only for initialization
-        super().__init__(room_size=room_size, mission_space=mission_space, max_steps=max_steps, **kwargs)
+            max_steps = 0  # only for initialization
+        super().__init__(
+            room_size=room_size,
+            mission_space=mission_space,
+            max_steps=max_steps,
+            **kwargs
+        )
 
     def reset(self, **kwargs):
         obs = super().reset(**kwargs)

--- a/minigrid/envs/babyai/core/roomgrid_level.py
+++ b/minigrid/envs/babyai/core/roomgrid_level.py
@@ -1,6 +1,8 @@
 """
 Copied and adapted from https://github.com/mila-iqia/babyai
 """
+from typing import Optional
+
 from minigrid.core.roomgrid import RoomGrid
 from minigrid.envs.babyai.core.verifier import (
     ActionInstr,
@@ -44,15 +46,17 @@ class RoomGridLevel(RoomGrid):
     of approximately similar difficulty.
     """
 
-    def __init__(self, room_size=8, **kwargs):
+    def __init__(self, room_size=8, max_steps: Optional[int] = None, **kwargs):
         mission_space = BabyAIMissionSpace()
 
         # If `max_steps` arg is passed it will be fixed for every episode,
         # if not it will vary after reset depending on the maze size.
         self.fixed_max_steps = False
-        if "max_steps" in kwargs:
+        if max_steps is not None:
             self.fixed_max_steps = True
-        super().__init__(room_size=room_size, mission_space=mission_space, **kwargs)
+        else:
+            max_steps = 0 # only for initialization
+        super().__init__(room_size=room_size, mission_space=mission_space, max_steps=max_steps, **kwargs)
 
     def reset(self, **kwargs):
         obs = super().reset(**kwargs)

--- a/minigrid/envs/babyai/core/roomgrid_level.py
+++ b/minigrid/envs/babyai/core/roomgrid_level.py
@@ -46,6 +46,12 @@ class RoomGridLevel(RoomGrid):
 
     def __init__(self, room_size=8, **kwargs):
         mission_space = BabyAIMissionSpace()
+
+        # If `max_steps` arg is passed it will be fixed for every episode,
+        # if not it will vary after reset depending on the maze size.
+        self.fixed_max_steps = False
+        if "max_steps" in kwargs:
+            self.fixed_max_steps = True
         super().__init__(room_size=room_size, mission_space=mission_space, **kwargs)
 
     def reset(self, **kwargs):
@@ -58,7 +64,9 @@ class RoomGridLevel(RoomGrid):
         nav_time_room = self.room_size**2
         nav_time_maze = nav_time_room * self.num_rows * self.num_cols
         num_navs = self.num_navs_needed(self.instrs)
-        self.max_steps = num_navs * nav_time_maze
+
+        if not self.fixed_max_steps:
+            self.max_steps = num_navs * nav_time_maze
 
         return obs
 

--- a/minigrid/envs/babyai/open.py
+++ b/minigrid/envs/babyai/open.py
@@ -98,14 +98,21 @@ class OpenTwoDoors(RoomGridLevel):
     This task requires memory (recurrent policy) to be solved effectively.
     """
 
-    def __init__(self, first_color=None, second_color=None, strict=False,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(
+        self,
+        first_color=None,
+        second_color=None,
+        strict=False,
+        max_steps: Optional[int] = None,
+        **kwargs
+    ):
         self.first_color = first_color
         self.second_color = second_color
         self.strict = strict
 
         room_size = 6
         if max_steps is None:
-            max_Steps = 20 * room_size**2
+            max_steps = 20 * room_size**2
 
         super().__init__(room_size=room_size, max_steps=max_steps, **kwargs)
 
@@ -135,7 +142,9 @@ class OpenDoorsOrder(RoomGridLevel):
     Open one or two doors in the order specified.
     """
 
-    def __init__(self, num_doors, debug=False,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(
+        self, num_doors, debug=False, max_steps: Optional[int] = None, **kwargs
+    ):
         assert num_doors >= 2
         self.num_doors = num_doors
         self.debug = debug

--- a/minigrid/envs/babyai/open.py
+++ b/minigrid/envs/babyai/open.py
@@ -104,7 +104,7 @@ class OpenTwoDoors(RoomGridLevel):
 
         room_size = 6
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 20 * room_size ** 2
+            kwargs["max_steps"] = 20 * room_size**2
 
         super().__init__(room_size=room_size, **kwargs)
 
@@ -141,7 +141,7 @@ class OpenDoorsOrder(RoomGridLevel):
 
         room_size = 6
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 20 * room_size ** 2
+            kwargs["max_steps"] = 20 * room_size**2
 
         super().__init__(room_size=room_size, **kwargs)
 

--- a/minigrid/envs/babyai/open.py
+++ b/minigrid/envs/babyai/open.py
@@ -2,6 +2,7 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Open` instruction.
 """
+from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel
@@ -97,16 +98,16 @@ class OpenTwoDoors(RoomGridLevel):
     This task requires memory (recurrent policy) to be solved effectively.
     """
 
-    def __init__(self, first_color=None, second_color=None, strict=False, **kwargs):
+    def __init__(self, first_color=None, second_color=None, strict=False,  max_steps: Optional[int] = None, **kwargs):
         self.first_color = first_color
         self.second_color = second_color
         self.strict = strict
 
         room_size = 6
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 20 * room_size**2
+        if max_steps is None:
+            max_Steps = 20 * room_size**2
 
-        super().__init__(room_size=room_size, **kwargs)
+        super().__init__(room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         colors = self._rand_subset(COLOR_NAMES, 2)
@@ -134,16 +135,16 @@ class OpenDoorsOrder(RoomGridLevel):
     Open one or two doors in the order specified.
     """
 
-    def __init__(self, num_doors, debug=False, **kwargs):
+    def __init__(self, num_doors, debug=False,  max_steps: Optional[int] = None, **kwargs):
         assert num_doors >= 2
         self.num_doors = num_doors
         self.debug = debug
 
         room_size = 6
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 20 * room_size**2
+        if max_steps is None:
+            max_steps = 20 * room_size**2
 
-        super().__init__(room_size=room_size, **kwargs)
+        super().__init__(room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         colors = self._rand_subset(COLOR_NAMES, self.num_doors)

--- a/minigrid/envs/babyai/open.py
+++ b/minigrid/envs/babyai/open.py
@@ -103,7 +103,10 @@ class OpenTwoDoors(RoomGridLevel):
         self.strict = strict
 
         room_size = 6
-        super().__init__(room_size=room_size, max_steps=20 * room_size**2, **kwargs)
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 20 * room_size ** 2
+
+        super().__init__(room_size=room_size, **kwargs)
 
     def gen_mission(self):
         colors = self._rand_subset(COLOR_NAMES, 2)
@@ -137,7 +140,10 @@ class OpenDoorsOrder(RoomGridLevel):
         self.debug = debug
 
         room_size = 6
-        super().__init__(room_size=room_size, max_steps=20 * room_size**2, **kwargs)
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 20 * room_size ** 2
+
+        super().__init__(room_size=room_size, **kwargs)
 
     def gen_mission(self):
         colors = self._rand_subset(COLOR_NAMES, self.num_doors)

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -51,12 +51,18 @@ class ActionObjDoor(RoomGridLevel):
 class FindObjS5(RoomGridLevel):
     """
     Pick up an object (in a random room)
-    Rooms have a size of 5
+    Rooms have a size of 5f
     This level requires potentially exhaustive exploration
     """
 
-    def __init__(self, room_size=5, **kwargs):
-        super().__init__(room_size=room_size, max_steps=20 * room_size**2, **kwargs)
+    def __init__(self,
+        room_size=5,  
+        **kwargs):
+        
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 20 * room_size ** 2
+
+        super().__init__(room_size=room_size, **kwargs)
 
     def gen_mission(self):
         # Add a random object to a random room
@@ -75,14 +81,16 @@ class KeyCorridor(RoomGridLevel):
     random room.
     """
 
-    def __init__(self, num_rows=3, obj_type="ball", room_size=6, **kwargs):
+    def __init__(
+        self, num_rows=3, obj_type="ball", room_size=6, **kwargs
+    ):
         self.obj_type = obj_type
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 30 * room_size ** 2
+
         super().__init__(
-            room_size=room_size,
-            num_rows=num_rows,
-            max_steps=30 * room_size**2,
-            **kwargs
+            room_size=room_size, num_rows=num_rows, **kwargs
         )
 
     def gen_mission(self):
@@ -134,12 +142,11 @@ class MoveTwoAcross(RoomGridLevel):
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 16 * room_size ** 2
+                
         super().__init__(
-            num_rows=1,
-            num_cols=2,
-            room_size=room_size,
-            max_steps=16 * room_size**2,
-            **kwargs
+            num_rows=1, num_cols=2, room_size=room_size, **kwargs
         )
 
     def gen_mission(self):

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -56,7 +56,7 @@ class FindObjS5(RoomGridLevel):
     This level requires potentially exhaustive exploration
     """
 
-    def __init__(self, room_size=5,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, room_size=5, max_steps: Optional[int] = None, **kwargs):
 
         if max_steps is None:
             max_steps = 20 * room_size**2
@@ -80,13 +80,22 @@ class KeyCorridor(RoomGridLevel):
     random room.
     """
 
-    def __init__(self, num_rows=3, obj_type="ball", room_size=6,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(
+        self,
+        num_rows=3,
+        obj_type="ball",
+        room_size=6,
+        max_steps: Optional[int] = None,
+        **kwargs
+    ):
         self.obj_type = obj_type
 
         if max_steps is None:
             max_steps = 30 * room_size**2
 
-        super().__init__(room_size=room_size, num_rows=num_rows, max_steps=max_steps, **kwargs)
+        super().__init__(
+            room_size=room_size, num_rows=num_rows, max_steps=max_steps, **kwargs
+        )
 
     def gen_mission(self):
         # Connect the middle column rooms into a hallway
@@ -133,14 +142,18 @@ class MoveTwoAcross(RoomGridLevel):
     instructions.
     """
 
-    def __init__(self, room_size, objs_per_room,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(
+        self, room_size, objs_per_room, max_steps: Optional[int] = None, **kwargs
+    ):
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room
 
         if max_steps is None:
             max_steps = 16 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs)
+        super().__init__(
+            num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs
+        )
 
     def gen_mission(self):
         self.place_agent(0, 0)

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -2,6 +2,7 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with different instructions than those in other files.
 """
+from typing import Optional
 
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel
 from minigrid.envs.babyai.core.verifier import (
@@ -55,12 +56,12 @@ class FindObjS5(RoomGridLevel):
     This level requires potentially exhaustive exploration
     """
 
-    def __init__(self, room_size=5, **kwargs):
+    def __init__(self, room_size=5,  max_steps: Optional[int] = None, **kwargs):
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 20 * room_size**2
+        if max_steps is None:
+            max_steps = 20 * room_size**2
 
-        super().__init__(room_size=room_size, **kwargs)
+        super().__init__(room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         # Add a random object to a random room
@@ -79,13 +80,13 @@ class KeyCorridor(RoomGridLevel):
     random room.
     """
 
-    def __init__(self, num_rows=3, obj_type="ball", room_size=6, **kwargs):
+    def __init__(self, num_rows=3, obj_type="ball", room_size=6,  max_steps: Optional[int] = None, **kwargs):
         self.obj_type = obj_type
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 30 * room_size**2
+        if max_steps is None:
+            max_steps = 30 * room_size**2
 
-        super().__init__(room_size=room_size, num_rows=num_rows, **kwargs)
+        super().__init__(room_size=room_size, num_rows=num_rows, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         # Connect the middle column rooms into a hallway
@@ -132,14 +133,14 @@ class MoveTwoAcross(RoomGridLevel):
     instructions.
     """
 
-    def __init__(self, room_size, objs_per_room, **kwargs):
+    def __init__(self, room_size, objs_per_room,  max_steps: Optional[int] = None, **kwargs):
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 16 * room_size**2
+        if max_steps is None:
+            max_steps = 16 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=room_size, **kwargs)
+        super().__init__(num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         self.place_agent(0, 0)

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -55,12 +55,10 @@ class FindObjS5(RoomGridLevel):
     This level requires potentially exhaustive exploration
     """
 
-    def __init__(self,
-        room_size=5,  
-        **kwargs):
-        
+    def __init__(self, room_size=5, **kwargs):
+
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 20 * room_size ** 2
+            kwargs["max_steps"] = 20 * room_size**2
 
         super().__init__(room_size=room_size, **kwargs)
 
@@ -81,17 +79,13 @@ class KeyCorridor(RoomGridLevel):
     random room.
     """
 
-    def __init__(
-        self, num_rows=3, obj_type="ball", room_size=6, **kwargs
-    ):
+    def __init__(self, num_rows=3, obj_type="ball", room_size=6, **kwargs):
         self.obj_type = obj_type
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 30 * room_size ** 2
+            kwargs["max_steps"] = 30 * room_size**2
 
-        super().__init__(
-            room_size=room_size, num_rows=num_rows, **kwargs
-        )
+        super().__init__(room_size=room_size, num_rows=num_rows, **kwargs)
 
     def gen_mission(self):
         # Connect the middle column rooms into a hallway
@@ -143,11 +137,9 @@ class MoveTwoAcross(RoomGridLevel):
         self.objs_per_room = objs_per_room
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 16 * room_size ** 2
-                
-        super().__init__(
-            num_rows=1, num_cols=2, room_size=room_size, **kwargs
-        )
+            kwargs["max_steps"] = 16 * room_size**2
+
+        super().__init__(num_rows=1, num_cols=2, room_size=room_size, **kwargs)
 
     def gen_mission(self):
         self.place_agent(0, 0)

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -52,7 +52,7 @@ class ActionObjDoor(RoomGridLevel):
 class FindObjS5(RoomGridLevel):
     """
     Pick up an object (in a random room)
-    Rooms have a size of 5f
+    Rooms have a size of 5
     This level requires potentially exhaustive exploration
     """
 

--- a/minigrid/envs/babyai/pickup.py
+++ b/minigrid/envs/babyai/pickup.py
@@ -102,7 +102,7 @@ class PickupAbove(RoomGridLevel):
     This task requires to use the compass to be solved effectively.
     """
 
-    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: Optional[int] = None, **kwargs):
         room_size = 6
         if max_steps is None:
             max_steps = 8 * room_size**2

--- a/minigrid/envs/babyai/pickup.py
+++ b/minigrid/envs/babyai/pickup.py
@@ -2,6 +2,7 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Pick up` instruction.
 """
+from typing import Optional
 
 from minigrid.envs.babyai.core.levelgen import LevelGen
 from minigrid.envs.babyai.core.roomgrid_level import RejectSampling, RoomGridLevel
@@ -101,12 +102,12 @@ class PickupAbove(RoomGridLevel):
     This task requires to use the compass to be solved effectively.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
         room_size = 6
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size**2
+        if max_steps is None:
+            max_steps = 8 * room_size**2
 
-        super().__init__(room_size=room_size, **kwargs)
+        super().__init__(room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         # Add a random object to the top-middle room

--- a/minigrid/envs/babyai/pickup.py
+++ b/minigrid/envs/babyai/pickup.py
@@ -103,7 +103,10 @@ class PickupAbove(RoomGridLevel):
 
     def __init__(self, **kwargs):
         room_size = 6
-        super().__init__(room_size=room_size, max_steps=8 * room_size**2, **kwargs)
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 8 * room_size**2
+
+        super().__init__(room_size=room_size, **kwargs)
 
     def gen_mission(self):
         # Add a random object to the top-middle room

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -36,7 +36,14 @@ class PutNext(RoomGridLevel):
     instructions.
     """
 
-    def __init__(self, room_size, objs_per_room, start_carrying=False,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(
+        self,
+        room_size,
+        objs_per_room,
+        start_carrying=False,
+        max_steps: Optional[int] = None,
+        **kwargs
+    ):
         assert room_size >= 4
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room
@@ -45,7 +52,9 @@ class PutNext(RoomGridLevel):
         if max_steps is None:
             max_steps = 8 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs)
+        super().__init__(
+            num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs
+        )
 
     def gen_mission(self):
         self.place_agent(0, 0)

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -35,9 +35,7 @@ class PutNext(RoomGridLevel):
     instructions.
     """
 
-    def __init__(
-        self, room_size, objs_per_room, start_carrying=False, **kwargs
-    ):
+    def __init__(self, room_size, objs_per_room, start_carrying=False, **kwargs):
         assert room_size >= 4
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room
@@ -46,9 +44,7 @@ class PutNext(RoomGridLevel):
         if "max_steps" not in kwargs:
             kwargs["max_steps"] = 8 * room_size**2
 
-        super().__init__(
-            num_rows=1, num_cols=2, room_size=room_size, **kwargs
-        )
+        super().__init__(num_rows=1, num_cols=2, room_size=room_size, **kwargs)
 
     def gen_mission(self):
         self.place_agent(0, 0)

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -2,6 +2,7 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Put Next` instruction.
 """
+from typing import Optional
 
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel
 from minigrid.envs.babyai.core.verifier import ObjDesc, PutNextInstr
@@ -35,16 +36,16 @@ class PutNext(RoomGridLevel):
     instructions.
     """
 
-    def __init__(self, room_size, objs_per_room, start_carrying=False, **kwargs):
+    def __init__(self, room_size, objs_per_room, start_carrying=False,  max_steps: Optional[int] = None, **kwargs):
         assert room_size >= 4
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room
         self.start_carrying = start_carrying
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size**2
+        if max_steps is None:
+            max_steps = 8 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=room_size, **kwargs)
+        super().__init__(num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         self.place_agent(0, 0)

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -35,18 +35,19 @@ class PutNext(RoomGridLevel):
     instructions.
     """
 
-    def __init__(self, room_size, objs_per_room, start_carrying=False, **kwargs):
+    def __init__(
+        self, room_size, objs_per_room, start_carrying=False, **kwargs
+    ):
         assert room_size >= 4
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room
         self.start_carrying = start_carrying
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 8 * room_size**2
+
         super().__init__(
-            num_rows=1,
-            num_cols=2,
-            room_size=room_size,
-            max_steps=8 * room_size**2,
-            **kwargs
+            num_rows=1, num_cols=2, room_size=room_size, **kwargs
         )
 
     def gen_mission(self):

--- a/minigrid/envs/babyai/unlock.py
+++ b/minigrid/envs/babyai/unlock.py
@@ -2,6 +2,7 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Unlock` instruction.
 """
+from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel
@@ -109,13 +110,13 @@ class UnlockPickup(RoomGridLevel):
     Unlock a door, then pick up a box in another room
     """
 
-    def __init__(self, distractors=False, **kwargs):
+    def __init__(self, distractors=False, max_steps: Optional[int] = None, **kwargs):
         self.distractors = distractors
         room_size = 6
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size**2
+        if max is None:
+            max_steps = 8 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=6, **kwargs)
+        super().__init__(num_rows=1, num_cols=2, room_size=6, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         # Add a random object to the room on the right
@@ -138,12 +139,12 @@ class BlockedUnlockPickup(RoomGridLevel):
     in another room
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
         room_size = 6
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 16 * room_size**2
+        if max_steps is None:
+            max_steps = 16 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=room_size, **kwargs)
+        super().__init__(num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         # Add a box to the room on the right
@@ -166,12 +167,12 @@ class UnlockToUnlock(RoomGridLevel):
     Unlock a door A that requires to unlock a door B before
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
         room_size = 6
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 30 * room_size**2
+        if max_steps is None:
+            max_steps = 30 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=3, room_size=room_size, **kwargs)
+        super().__init__(num_rows=1, num_cols=3, room_size=room_size, max_steps=max_steps, **kwargs)
 
     def gen_mission(self):
         colors = self._rand_subset(COLOR_NAMES, 2)

--- a/minigrid/envs/babyai/unlock.py
+++ b/minigrid/envs/babyai/unlock.py
@@ -109,17 +109,13 @@ class UnlockPickup(RoomGridLevel):
     Unlock a door, then pick up a box in another room
     """
 
-    def __init__(
-        self, distractors=False, **kwargs
-    ):
+    def __init__(self, distractors=False, **kwargs):
         self.distractors = distractors
         room_size = 6
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size ** 2
+            kwargs["max_steps"] = 8 * room_size**2
 
-        super().__init__(
-            num_rows=1, num_cols=2, room_size=6, **kwargs
-        )
+        super().__init__(num_rows=1, num_cols=2, room_size=6, **kwargs)
 
     def gen_mission(self):
         # Add a random object to the room on the right
@@ -145,11 +141,9 @@ class BlockedUnlockPickup(RoomGridLevel):
     def __init__(self, **kwargs):
         room_size = 6
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 16 * room_size ** 2
+            kwargs["max_steps"] = 16 * room_size**2
 
-        super().__init__(
-            num_rows=1, num_cols=2, room_size=room_size, **kwargs
-        )
+        super().__init__(num_rows=1, num_cols=2, room_size=room_size, **kwargs)
 
     def gen_mission(self):
         # Add a box to the room on the right
@@ -175,11 +169,9 @@ class UnlockToUnlock(RoomGridLevel):
     def __init__(self, **kwargs):
         room_size = 6
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 30 * room_size ** 2
+            kwargs["max_steps"] = 30 * room_size**2
 
-        super().__init__(
-            num_rows=1, num_cols=3, room_size=room_size, **kwargs
-        )
+        super().__init__(num_rows=1, num_cols=3, room_size=room_size, **kwargs)
 
     def gen_mission(self):
         colors = self._rand_subset(COLOR_NAMES, 2)

--- a/minigrid/envs/babyai/unlock.py
+++ b/minigrid/envs/babyai/unlock.py
@@ -109,16 +109,16 @@ class UnlockPickup(RoomGridLevel):
     Unlock a door, then pick up a box in another room
     """
 
-    def __init__(self, distractors=False, **kwargs):
+    def __init__(
+        self, distractors=False, **kwargs
+    ):
         self.distractors = distractors
-
         room_size = 6
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 8 * room_size ** 2
+
         super().__init__(
-            num_rows=1,
-            num_cols=2,
-            room_size=room_size,
-            max_steps=8 * room_size**2,
-            **kwargs
+            num_rows=1, num_cols=2, room_size=6, **kwargs
         )
 
     def gen_mission(self):
@@ -144,12 +144,11 @@ class BlockedUnlockPickup(RoomGridLevel):
 
     def __init__(self, **kwargs):
         room_size = 6
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 16 * room_size ** 2
+
         super().__init__(
-            num_rows=1,
-            num_cols=2,
-            room_size=room_size,
-            max_steps=16 * room_size**2,
-            **kwargs
+            num_rows=1, num_cols=2, room_size=room_size, **kwargs
         )
 
     def gen_mission(self):
@@ -175,12 +174,11 @@ class UnlockToUnlock(RoomGridLevel):
 
     def __init__(self, **kwargs):
         room_size = 6
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 30 * room_size ** 2
+
         super().__init__(
-            num_rows=1,
-            num_cols=3,
-            room_size=room_size,
-            max_steps=30 * room_size**2,
-            **kwargs
+            num_rows=1, num_cols=3, room_size=room_size, **kwargs
         )
 
     def gen_mission(self):

--- a/minigrid/envs/babyai/unlock.py
+++ b/minigrid/envs/babyai/unlock.py
@@ -116,7 +116,9 @@ class UnlockPickup(RoomGridLevel):
         if max is None:
             max_steps = 8 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=6, max_steps=max_steps, **kwargs)
+        super().__init__(
+            num_rows=1, num_cols=2, room_size=6, max_steps=max_steps, **kwargs
+        )
 
     def gen_mission(self):
         # Add a random object to the room on the right
@@ -139,12 +141,14 @@ class BlockedUnlockPickup(RoomGridLevel):
     in another room
     """
 
-    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: Optional[int] = None, **kwargs):
         room_size = 6
         if max_steps is None:
             max_steps = 16 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs)
+        super().__init__(
+            num_rows=1, num_cols=2, room_size=room_size, max_steps=max_steps, **kwargs
+        )
 
     def gen_mission(self):
         # Add a box to the room on the right
@@ -167,12 +171,14 @@ class UnlockToUnlock(RoomGridLevel):
     Unlock a door A that requires to unlock a door B before
     """
 
-    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: Optional[int] = None, **kwargs):
         room_size = 6
         if max_steps is None:
             max_steps = 30 * room_size**2
 
-        super().__init__(num_rows=1, num_cols=3, room_size=room_size, max_steps=max_steps, **kwargs)
+        super().__init__(
+            num_rows=1, num_cols=3, room_size=room_size, max_steps=max_steps, **kwargs
+        )
 
     def gen_mission(self):
         colors = self._rand_subset(COLOR_NAMES, 2)

--- a/minigrid/envs/blockedunlockpickup.py
+++ b/minigrid/envs/blockedunlockpickup.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid
@@ -63,21 +65,22 @@ class BlockedUnlockPickupEnv(RoomGrid):
 
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, max_steps: Optional[int] = None, **kwargs):
         mission_space = MissionSpace(
             mission_func=lambda color, type: f"pick up the {color} {type}",
             ordered_placeholders=[COLOR_NAMES, ["box", "key"]],
         )
 
         room_size = 6
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 16 * room_size**2
+        if max_steps is None:
+            max_steps = 16 * room_size**2
 
         super().__init__(
             mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/blockedunlockpickup.py
+++ b/minigrid/envs/blockedunlockpickup.py
@@ -63,8 +63,7 @@ class BlockedUnlockPickupEnv(RoomGrid):
 
     """
 
-    def __init__(self, 
-        **kwargs):
+    def __init__(self, **kwargs):
         mission_space = MissionSpace(
             mission_func=lambda color, type: f"pick up the {color} {type}",
             ordered_placeholders=[COLOR_NAMES, ["box", "key"]],
@@ -72,7 +71,7 @@ class BlockedUnlockPickupEnv(RoomGrid):
 
         room_size = 6
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 16 * room_size ** 2
+            kwargs["max_steps"] = 16 * room_size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/blockedunlockpickup.py
+++ b/minigrid/envs/blockedunlockpickup.py
@@ -63,18 +63,22 @@ class BlockedUnlockPickupEnv(RoomGrid):
 
     """
 
-    def __init__(self, **kwargs):
-        room_size = 6
+    def __init__(self, 
+        **kwargs):
         mission_space = MissionSpace(
             mission_func=lambda color, type: f"pick up the {color} {type}",
             ordered_placeholders=[COLOR_NAMES, ["box", "key"]],
         )
+
+        room_size = 6
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 16 * room_size ** 2
+
         super().__init__(
             mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,
-            max_steps=16 * room_size**2,
             **kwargs,
         )
 

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -112,7 +112,7 @@ class CrossingEnv(MiniGridEnv):
             )
 
         if max_steps is None:
-            max_steps = 4 * size * size
+            max_steps = 4 * size ** 2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -90,13 +90,7 @@ class CrossingEnv(MiniGridEnv):
 
     """
 
-    def __init__(
-        self,
-        size=9,
-        num_crossings=1,
-        obstacle_type=Lava,
-        **kwargs
-    ):
+    def __init__(self, size=9, num_crossings=1, obstacle_type=Lava, **kwargs):
         self.num_crossings = num_crossings
         self.obstacle_type = obstacle_type
 

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -112,7 +112,7 @@ class CrossingEnv(MiniGridEnv):
             )
 
         if max_steps is None:
-            max_steps = 4 * size ** 2
+            max_steps = 4 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -90,7 +90,13 @@ class CrossingEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=9, num_crossings=1, obstacle_type=Lava, **kwargs):
+    def __init__(
+        self,
+        size=9,
+        num_crossings=1,
+        obstacle_type=Lava,
+        **kwargs
+    ):
         self.num_crossings = num_crossings
         self.obstacle_type = obstacle_type
 
@@ -103,12 +109,13 @@ class CrossingEnv(MiniGridEnv):
                 mission_func=lambda: "find the opening and get to the green goal square"
             )
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 4 * size * size
+
         super().__init__(
             mission_space=mission_space,
             grid_size=size,
-            max_steps=4 * size * size,
-            # Set this to True for maximum speed
-            see_through_walls=False,
+            see_through_walls=False,  # Set this to True for maximum speed
             **kwargs
         )
 

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -1,4 +1,5 @@
 import itertools as itt
+from typing import Optional
 
 import numpy as np
 
@@ -90,7 +91,14 @@ class CrossingEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=9, num_crossings=1, obstacle_type=Lava, **kwargs):
+    def __init__(
+        self,
+        size=9,
+        num_crossings=1,
+        obstacle_type=Lava,
+        max_steps: Optional[int] = None,
+        **kwargs
+    ):
         self.num_crossings = num_crossings
         self.obstacle_type = obstacle_type
 
@@ -103,13 +111,14 @@ class CrossingEnv(MiniGridEnv):
                 mission_func=lambda: "find the opening and get to the green goal square"
             )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * size * size
+        if max_steps is None:
+            max_steps = 4 * size * size
 
         super().__init__(
             mission_space=mission_space,
             grid_size=size,
             see_through_walls=False,  # Set this to True for maximum speed
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/distshift.py
+++ b/minigrid/envs/distshift.py
@@ -81,11 +81,13 @@ class DistShiftEnv(MiniGridEnv):
             mission_func=lambda: "get to the green goal square"
         )
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 4 * width * height
+
         super().__init__(
             mission_space=mission_space,
             width=width,
             height=height,
-            max_steps=4 * width * height,
             # Set this to True for maximum speed
             see_through_walls=True,
             **kwargs

--- a/minigrid/envs/distshift.py
+++ b/minigrid/envs/distshift.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Goal, Lava
@@ -70,6 +72,7 @@ class DistShiftEnv(MiniGridEnv):
         agent_start_pos=(1, 1),
         agent_start_dir=0,
         strip2_row=2,
+        max_steps: Optional[int] = None,
         **kwargs
     ):
         self.agent_start_pos = agent_start_pos
@@ -81,8 +84,8 @@ class DistShiftEnv(MiniGridEnv):
             mission_func=lambda: "get to the green goal square"
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * width * height
+        if max_steps is None:
+            max_steps = 4 * width * height
 
         super().__init__(
             mission_space=mission_space,
@@ -90,6 +93,7 @@ class DistShiftEnv(MiniGridEnv):
             height=height,
             # Set this to True for maximum speed
             see_through_walls=True,
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -64,7 +64,7 @@ class DoorKeyEnv(MiniGridEnv):
 
     def __init__(self, size=8, max_steps: Optional[int] = None, **kwargs):
         if max_steps is None:
-            max_steps = 10 * size ** 2
+            max_steps = 10 * size**2
         mission_space = MissionSpace(
             mission_func=lambda: "use the key to open the door and then get to the goal"
         )

--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -64,7 +64,7 @@ class DoorKeyEnv(MiniGridEnv):
 
     def __init__(self, size=8, max_steps: Optional[int] = None, **kwargs):
         if max_steps is None:
-            max_steps = 10 * size * size
+            max_steps = 10 * size ** 2
         mission_space = MissionSpace(
             mission_func=lambda: "use the key to open the door and then get to the goal"
         )

--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Door, Goal, Key
@@ -60,13 +62,15 @@ class DoorKeyEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, **kwargs):
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 10 * size * size
+    def __init__(self, size=8, max_steps: Optional[int] = None, **kwargs):
+        if max_steps is None:
+            max_steps = 10 * size * size
         mission_space = MissionSpace(
             mission_func=lambda: "use the key to open the door and then get to the goal"
         )
-        super().__init__(mission_space=mission_space, grid_size=size, **kwargs)
+        super().__init__(
+            mission_space=mission_space, grid_size=size, max_steps=max_steps, **kwargs
+        )
 
     def _gen_grid(self, width, height):
         # Create an empty grid

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -93,7 +93,7 @@ class DynamicObstaclesEnv(MiniGridEnv):
         )
 
         if max_steps is None:
-            max_steps = 4 * size * size
+            max_steps = 4 * size ** 2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -93,7 +93,7 @@ class DynamicObstaclesEnv(MiniGridEnv):
         )
 
         if max_steps is None:
-            max_steps = 4 * size ** 2
+            max_steps = 4 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -70,7 +70,12 @@ class DynamicObstaclesEnv(MiniGridEnv):
     """
 
     def __init__(
-        self, size=8, agent_start_pos=(1, 1), agent_start_dir=0, n_obstacles=4, **kwargs
+        self,
+        size=8,
+        agent_start_pos=(1, 1),
+        agent_start_dir=0,
+        n_obstacles=4,
+        **kwargs
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -85,10 +90,12 @@ class DynamicObstaclesEnv(MiniGridEnv):
             mission_func=lambda: "get to the green goal square"
         )
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 4 * size * size
+
         super().__init__(
             mission_space=mission_space,
             grid_size=size,
-            max_steps=4 * size * size,
             # Set this to True for maximum speed
             see_through_walls=True,
             **kwargs

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -70,12 +70,7 @@ class DynamicObstaclesEnv(MiniGridEnv):
     """
 
     def __init__(
-        self,
-        size=8,
-        agent_start_pos=(1, 1),
-        agent_start_dir=0,
-        n_obstacles=4,
-        **kwargs
+        self, size=8, agent_start_pos=(1, 1), agent_start_dir=0, n_obstacles=4, **kwargs
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -1,4 +1,5 @@
 from operator import add
+from typing import Optional
 
 from gymnasium.spaces import Discrete
 
@@ -70,7 +71,13 @@ class DynamicObstaclesEnv(MiniGridEnv):
     """
 
     def __init__(
-        self, size=8, agent_start_pos=(1, 1), agent_start_dir=0, n_obstacles=4, **kwargs
+        self,
+        size=8,
+        agent_start_pos=(1, 1),
+        agent_start_dir=0,
+        n_obstacles=4,
+        max_steps: Optional[int] = None,
+        **kwargs
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -85,14 +92,15 @@ class DynamicObstaclesEnv(MiniGridEnv):
             mission_func=lambda: "get to the green goal square"
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * size * size
+        if max_steps is None:
+            max_steps = 4 * size * size
 
         super().__init__(
             mission_space=mission_space,
             grid_size=size,
             # Set this to True for maximum speed
             see_through_walls=True,
+            max_steps=max_steps,
             **kwargs
         )
         # Allow only 3 actions permitted: left, right, forward

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -65,7 +65,13 @@ class EmptyEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, agent_start_pos=(1, 1), agent_start_dir=0, **kwargs):
+    def __init__(
+        self,
+        size=8,
+        agent_start_pos=(1, 1),
+        agent_start_dir=0,
+        **kwargs
+    ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
 
@@ -73,10 +79,12 @@ class EmptyEnv(MiniGridEnv):
             mission_func=lambda: "get to the green goal square"
         )
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 4 * size * size
+
         super().__init__(
             mission_space=mission_space,
             grid_size=size,
-            max_steps=4 * size * size,
             # Set this to True for maximum speed
             see_through_walls=True,
             **kwargs

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -83,7 +83,7 @@ class EmptyEnv(MiniGridEnv):
         )
 
         if max_steps is None:
-            max_steps = 4 * size ** 2
+            max_steps = 4 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -65,13 +65,7 @@ class EmptyEnv(MiniGridEnv):
 
     """
 
-    def __init__(
-        self,
-        size=8,
-        agent_start_pos=(1, 1),
-        agent_start_dir=0,
-        **kwargs
-    ):
+    def __init__(self, size=8, agent_start_pos=(1, 1), agent_start_dir=0, **kwargs):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
 

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -83,7 +83,7 @@ class EmptyEnv(MiniGridEnv):
         )
 
         if max_steps is None:
-            max_steps = 4 * size * size
+            max_steps = 4 * size ** 2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Goal
@@ -65,7 +67,14 @@ class EmptyEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, agent_start_pos=(1, 1), agent_start_dir=0, **kwargs):
+    def __init__(
+        self,
+        size=8,
+        agent_start_pos=(1, 1),
+        agent_start_dir=0,
+        max_steps: Optional[int] = None,
+        **kwargs
+    ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
 
@@ -73,14 +82,15 @@ class EmptyEnv(MiniGridEnv):
             mission_func=lambda: "get to the green goal square"
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * size * size
+        if max_steps is None:
+            max_steps = 4 * size * size
 
         super().__init__(
             mission_space=mission_space,
             grid_size=size,
             # Set this to True for maximum speed
             see_through_walls=True,
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/fetch.py
+++ b/minigrid/envs/fetch.py
@@ -71,7 +71,9 @@ class FetchEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, numObjs=3, **kwargs):
+    def __init__(
+        self, size=8, numObjs=3, **kwargs
+    ):
         self.numObjs = numObjs
         self.obj_types = ["key", "ball"]
 
@@ -87,11 +89,14 @@ class FetchEnv(MiniGridEnv):
             mission_func=lambda syntax, color, type: f"{syntax} {color} {type}",
             ordered_placeholders=[MISSION_SYNTAX, COLOR_NAMES, self.obj_types],
         )
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 5 * size ** 2
+
         super().__init__(
             mission_space=mission_space,
             width=size,
             height=size,
-            max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=True,
             **kwargs,

--- a/minigrid/envs/fetch.py
+++ b/minigrid/envs/fetch.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
@@ -71,7 +73,7 @@ class FetchEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, numObjs=3, **kwargs):
+    def __init__(self, size=8, numObjs=3, max_steps: Optional[int] = None, **kwargs):
         self.numObjs = numObjs
         self.obj_types = ["key", "ball"]
 
@@ -88,8 +90,8 @@ class FetchEnv(MiniGridEnv):
             ordered_placeholders=[MISSION_SYNTAX, COLOR_NAMES, self.obj_types],
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 5 * size**2
+        if max_steps is None:
+            max_steps = 5 * size**2
 
         super().__init__(
             mission_space=mission_space,
@@ -97,6 +99,7 @@ class FetchEnv(MiniGridEnv):
             height=size,
             # Set this to True for maximum speed
             see_through_walls=True,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/fetch.py
+++ b/minigrid/envs/fetch.py
@@ -71,9 +71,7 @@ class FetchEnv(MiniGridEnv):
 
     """
 
-    def __init__(
-        self, size=8, numObjs=3, **kwargs
-    ):
+    def __init__(self, size=8, numObjs=3, **kwargs):
         self.numObjs = numObjs
         self.obj_types = ["key", "ball"]
 
@@ -91,7 +89,7 @@ class FetchEnv(MiniGridEnv):
         )
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 5 * size ** 2
+            kwargs["max_steps"] = 5 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/fourrooms.py
+++ b/minigrid/envs/fourrooms.py
@@ -57,7 +57,7 @@ class FourRoomsEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, agent_pos=None, goal_pos=None, **kwargs):
+    def __init__(self, agent_pos=None, goal_pos=None, max_steps=100, **kwargs):
         self._agent_default_pos = agent_pos
         self._goal_default_pos = goal_pos
 
@@ -68,7 +68,7 @@ class FourRoomsEnv(MiniGridEnv):
             mission_space=mission_space,
             width=self.size,
             height=self.size,
-            max_steps=100,
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/gotodoor.py
+++ b/minigrid/envs/gotodoor.py
@@ -63,18 +63,23 @@ class GoToDoorEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=5, **kwargs):
+    def __init__(
+        self, size=5, **kwargs
+    ):
         assert size >= 5
         self.size = size
         mission_space = MissionSpace(
             mission_func=lambda color: f"go to the {color} door",
             ordered_placeholders=[COLOR_NAMES],
         )
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 4 * size ** 2
+
         super().__init__(
             mission_space=mission_space,
             width=size,
             height=size,
-            max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=True,
             **kwargs,

--- a/minigrid/envs/gotodoor.py
+++ b/minigrid/envs/gotodoor.py
@@ -63,9 +63,7 @@ class GoToDoorEnv(MiniGridEnv):
 
     """
 
-    def __init__(
-        self, size=5, **kwargs
-    ):
+    def __init__(self, size=5, **kwargs):
         assert size >= 5
         self.size = size
         mission_space = MissionSpace(
@@ -74,7 +72,7 @@ class GoToDoorEnv(MiniGridEnv):
         )
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * size ** 2
+            kwargs["max_steps"] = 4 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/gotodoor.py
+++ b/minigrid/envs/gotodoor.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
@@ -63,7 +65,7 @@ class GoToDoorEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=5, **kwargs):
+    def __init__(self, size=5, max_steps: Optional[int] = None, **kwargs):
         assert size >= 5
         self.size = size
         mission_space = MissionSpace(
@@ -71,8 +73,8 @@ class GoToDoorEnv(MiniGridEnv):
             ordered_placeholders=[COLOR_NAMES],
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * size**2
+        if max_steps is None:
+            max_steps = 4 * size**2
 
         super().__init__(
             mission_space=mission_space,
@@ -80,6 +82,7 @@ class GoToDoorEnv(MiniGridEnv):
             height=size,
             # Set this to True for maximum speed
             see_through_walls=True,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/gotoobject.py
+++ b/minigrid/envs/gotoobject.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
@@ -11,7 +13,7 @@ class GoToObjectEnv(MiniGridEnv):
     named using an English text string
     """
 
-    def __init__(self, size=6, numObjs=2, **kwargs):
+    def __init__(self, size=6, numObjs=2, max_steps: Optional[int] = None, **kwargs):
 
         self.numObjs = numObjs
         self.size = size
@@ -23,8 +25,8 @@ class GoToObjectEnv(MiniGridEnv):
             ordered_placeholders=[COLOR_NAMES, self.obj_types],
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 5 * size**2
+        if max_steps is None:
+            max_steps = 5 * size**2
 
         super().__init__(
             mission_space=mission_space,
@@ -32,6 +34,7 @@ class GoToObjectEnv(MiniGridEnv):
             height=size,
             # Set this to True for maximum speed
             see_through_walls=True,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/gotoobject.py
+++ b/minigrid/envs/gotoobject.py
@@ -11,7 +11,10 @@ class GoToObjectEnv(MiniGridEnv):
     named using an English text string
     """
 
-    def __init__(self, size=6, numObjs=2, **kwargs):
+    def __init__(
+        self, size=6, numObjs=2, **kwargs
+    ):
+
         self.numObjs = numObjs
         self.size = size
         # Types of objects to be generated
@@ -21,11 +24,14 @@ class GoToObjectEnv(MiniGridEnv):
             mission_func=lambda color, type: f"go to the {color} {type}",
             ordered_placeholders=[COLOR_NAMES, self.obj_types],
         )
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 5 * size ** 2
+
         super().__init__(
             mission_space=mission_space,
             width=size,
             height=size,
-            max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=True,
             **kwargs,

--- a/minigrid/envs/gotoobject.py
+++ b/minigrid/envs/gotoobject.py
@@ -11,9 +11,7 @@ class GoToObjectEnv(MiniGridEnv):
     named using an English text string
     """
 
-    def __init__(
-        self, size=6, numObjs=2, **kwargs
-    ):
+    def __init__(self, size=6, numObjs=2, **kwargs):
 
         self.numObjs = numObjs
         self.size = size
@@ -26,7 +24,7 @@ class GoToObjectEnv(MiniGridEnv):
         )
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 5 * size ** 2
+            kwargs["max_steps"] = 5 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/keycorridor.py
+++ b/minigrid/envs/keycorridor.py
@@ -77,9 +77,7 @@ class KeyCorridorEnv(RoomGrid):
 
     """
 
-    def __init__(
-        self, num_rows=3, obj_type="ball", room_size=6, **kwargs
-    ):
+    def __init__(self, num_rows=3, obj_type="ball", room_size=6, **kwargs):
         self.obj_type = obj_type
         mission_space = MissionSpace(
             mission_func=lambda color: f"pick up the {color} {obj_type}",
@@ -87,7 +85,7 @@ class KeyCorridorEnv(RoomGrid):
         )
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 30 * room_size ** 2
+            kwargs["max_steps"] = 30 * room_size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/keycorridor.py
+++ b/minigrid/envs/keycorridor.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid
@@ -77,20 +79,28 @@ class KeyCorridorEnv(RoomGrid):
 
     """
 
-    def __init__(self, num_rows=3, obj_type="ball", room_size=6, **kwargs):
+    def __init__(
+        self,
+        num_rows=3,
+        obj_type="ball",
+        room_size=6,
+        max_steps: Optional[int] = None,
+        **kwargs,
+    ):
         self.obj_type = obj_type
         mission_space = MissionSpace(
             mission_func=lambda color: f"pick up the {color} {obj_type}",
             ordered_placeholders=[COLOR_NAMES],
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 30 * room_size**2
+        if max_steps is None:
+            max_steps = 30 * room_size**2
 
         super().__init__(
             mission_space=mission_space,
             room_size=room_size,
             num_rows=num_rows,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/keycorridor.py
+++ b/minigrid/envs/keycorridor.py
@@ -77,17 +77,22 @@ class KeyCorridorEnv(RoomGrid):
 
     """
 
-    def __init__(self, num_rows=3, obj_type="ball", room_size=6, **kwargs):
+    def __init__(
+        self, num_rows=3, obj_type="ball", room_size=6, **kwargs
+    ):
         self.obj_type = obj_type
         mission_space = MissionSpace(
             mission_func=lambda color: f"pick up the {color} {obj_type}",
             ordered_placeholders=[COLOR_NAMES],
         )
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 30 * room_size ** 2
+
         super().__init__(
             mission_space=mission_space,
             room_size=room_size,
             num_rows=num_rows,
-            max_steps=30 * room_size**2,
             **kwargs,
         )
 

--- a/minigrid/envs/lavagap.py
+++ b/minigrid/envs/lavagap.py
@@ -69,7 +69,7 @@ class LavaGapEnv(MiniGridEnv):
     def __init__(self, size, obstacle_type=Lava, **kwargs):
         self.obstacle_type = obstacle_type
         self.size = size
-        
+
         if obstacle_type == Lava:
             mission_space = MissionSpace(
                 mission_func=lambda: "avoid the lava and get to the green goal square"
@@ -80,7 +80,7 @@ class LavaGapEnv(MiniGridEnv):
             )
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * size ** 2
+            kwargs["max_steps"] = 4 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/lavagap.py
+++ b/minigrid/envs/lavagap.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from minigrid.core.grid import Grid
@@ -66,7 +68,9 @@ class LavaGapEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size, obstacle_type=Lava, **kwargs):
+    def __init__(
+        self, size, obstacle_type=Lava, max_steps: Optional[int] = None, **kwargs
+    ):
         self.obstacle_type = obstacle_type
         self.size = size
 
@@ -79,8 +83,8 @@ class LavaGapEnv(MiniGridEnv):
                 mission_func=lambda: "find the opening and get to the green goal square"
             )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * size**2
+        if max_steps is None:
+            max_steps = 4 * size**2
 
         super().__init__(
             mission_space=mission_space,
@@ -88,6 +92,7 @@ class LavaGapEnv(MiniGridEnv):
             height=size,
             # Set this to True for maximum speed
             see_through_walls=False,
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/lavagap.py
+++ b/minigrid/envs/lavagap.py
@@ -69,7 +69,7 @@ class LavaGapEnv(MiniGridEnv):
     def __init__(self, size, obstacle_type=Lava, **kwargs):
         self.obstacle_type = obstacle_type
         self.size = size
-
+        
         if obstacle_type == Lava:
             mission_space = MissionSpace(
                 mission_func=lambda: "avoid the lava and get to the green goal square"
@@ -79,11 +79,13 @@ class LavaGapEnv(MiniGridEnv):
                 mission_func=lambda: "find the opening and get to the green goal square"
             )
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 4 * size ** 2
+
         super().__init__(
             mission_space=mission_space,
             width=size,
             height=size,
-            max_steps=4 * size * size,
             # Set this to True for maximum speed
             see_through_walls=False,
             **kwargs

--- a/minigrid/envs/lockedroom.py
+++ b/minigrid/envs/lockedroom.py
@@ -76,6 +76,9 @@ class LockedRoomEnv(MiniGridEnv):
 
     def __init__(self, size=19, **kwargs):
         self.size = size
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 10 * size
         mission_space = MissionSpace(
             mission_func=lambda lockedroom_color, keyroom_color, door_color: f"get the {lockedroom_color} key from the {keyroom_color} room, unlock the {door_color} door and go to the goal",
             ordered_placeholders=[COLOR_NAMES] * 3,
@@ -84,7 +87,6 @@ class LockedRoomEnv(MiniGridEnv):
             mission_space=mission_space,
             width=size,
             height=size,
-            max_steps=10 * size,
             **kwargs,
         )
 

--- a/minigrid/envs/lockedroom.py
+++ b/minigrid/envs/lockedroom.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
@@ -74,11 +76,11 @@ class LockedRoomEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=19, **kwargs):
+    def __init__(self, size=19, max_steps: Optional[int] = None, **kwargs):
         self.size = size
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 10 * size
+        if max_steps is None:
+            max_steps = 10 * size
         mission_space = MissionSpace(
             mission_func=lambda lockedroom_color, keyroom_color, door_color: f"get the {lockedroom_color} key from the {keyroom_color} room, unlock the {door_color} door and go to the goal",
             ordered_placeholders=[COLOR_NAMES] * 3,
@@ -87,6 +89,7 @@ class LockedRoomEnv(MiniGridEnv):
             mission_space=mission_space,
             width=size,
             height=size,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/memory.py
+++ b/minigrid/envs/memory.py
@@ -70,7 +70,7 @@ class MemoryEnv(MiniGridEnv):
         self.random_length = random_length
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 5 * size ** 2
+            kwargs["max_steps"] = 5 * size**2
 
         mission_space = MissionSpace(
             mission_func=lambda: "go to the matching object at the end of the hallway"

--- a/minigrid/envs/memory.py
+++ b/minigrid/envs/memory.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from minigrid.core.actions import Actions
@@ -65,12 +67,14 @@ class MemoryEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, random_length=False, **kwargs):
+    def __init__(
+        self, size=8, random_length=False, max_steps: Optional[int] = None, **kwargs
+    ):
         self.size = size
         self.random_length = random_length
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 5 * size**2
+        if max_steps is None:
+            max_steps = 5 * size**2
 
         mission_space = MissionSpace(
             mission_func=lambda: "go to the matching object at the end of the hallway"
@@ -81,6 +85,7 @@ class MemoryEnv(MiniGridEnv):
             height=size,
             # Set this to True for maximum speed
             see_through_walls=False,
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/memory.py
+++ b/minigrid/envs/memory.py
@@ -68,6 +68,10 @@ class MemoryEnv(MiniGridEnv):
     def __init__(self, size=8, random_length=False, **kwargs):
         self.size = size
         self.random_length = random_length
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 5 * size ** 2
+
         mission_space = MissionSpace(
             mission_func=lambda: "go to the matching object at the end of the hallway"
         )
@@ -75,7 +79,6 @@ class MemoryEnv(MiniGridEnv):
             mission_space=mission_space,
             width=size,
             height=size,
-            max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=False,
             **kwargs

--- a/minigrid/envs/multiroom.py
+++ b/minigrid/envs/multiroom.py
@@ -89,11 +89,13 @@ class MultiRoomEnv(MiniGridEnv):
 
         self.size = 25
 
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = maxNumRooms * 20
+
         super().__init__(
             mission_space=mission_space,
             width=self.size,
             height=self.size,
-            max_steps=self.maxNumRooms * 20,
             **kwargs
         )
 

--- a/minigrid/envs/multiroom.py
+++ b/minigrid/envs/multiroom.py
@@ -93,10 +93,7 @@ class MultiRoomEnv(MiniGridEnv):
             kwargs["max_steps"] = maxNumRooms * 20
 
         super().__init__(
-            mission_space=mission_space,
-            width=self.size,
-            height=self.size,
-            **kwargs
+            mission_space=mission_space, width=self.size, height=self.size, **kwargs
         )
 
     def _gen_grid(self, width, height):

--- a/minigrid/envs/multiroom.py
+++ b/minigrid/envs/multiroom.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
@@ -72,7 +74,14 @@ class MultiRoomEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, minNumRooms, maxNumRooms, maxRoomSize=10, **kwargs):
+    def __init__(
+        self,
+        minNumRooms,
+        maxNumRooms,
+        maxRoomSize=10,
+        max_steps: Optional[int] = None,
+        **kwargs
+    ):
         assert minNumRooms > 0
         assert maxNumRooms >= minNumRooms
         assert maxRoomSize >= 4
@@ -89,11 +98,15 @@ class MultiRoomEnv(MiniGridEnv):
 
         self.size = 25
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = maxNumRooms * 20
+        if max_steps is None:
+            max_steps = maxNumRooms * 20
 
         super().__init__(
-            mission_space=mission_space, width=self.size, height=self.size, **kwargs
+            mission_space=mission_space,
+            width=self.size,
+            height=self.size,
+            max_steps=max_steps,
+            **kwargs
         )
 
     def _gen_grid(self, width, height):

--- a/minigrid/envs/obstructedmaze.py
+++ b/minigrid/envs/obstructedmaze.py
@@ -81,7 +81,9 @@ class ObstructedMazeEnv(RoomGrid):
 
     def __init__(self, num_rows, num_cols, num_rooms_visited, **kwargs):
         room_size = 6
-        max_steps = 4 * num_rooms_visited * room_size**2
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 4 * num_rooms_visited * room_size ** 2
 
         mission_space = MissionSpace(
             mission_func=lambda: f"pick up the {COLOR_NAMES[0]} ball",
@@ -91,7 +93,6 @@ class ObstructedMazeEnv(RoomGrid):
             room_size=room_size,
             num_rows=num_rows,
             num_cols=num_cols,
-            max_steps=max_steps,
             **kwargs,
         )
         self.obj = Ball()  # initialize the obj attribute, that will be changed later on

--- a/minigrid/envs/obstructedmaze.py
+++ b/minigrid/envs/obstructedmaze.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES, DIR_TO_VEC
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid
@@ -79,11 +81,18 @@ class ObstructedMazeEnv(RoomGrid):
 
     """
 
-    def __init__(self, num_rows, num_cols, num_rooms_visited, **kwargs):
+    def __init__(
+        self,
+        num_rows,
+        num_cols,
+        num_rooms_visited,
+        max_steps: Optional[int] = None,
+        **kwargs,
+    ):
         room_size = 6
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * num_rooms_visited * room_size**2
+        if max_steps is None:
+            max_steps = 4 * num_rooms_visited * room_size**2
 
         mission_space = MissionSpace(
             mission_func=lambda: f"pick up the {COLOR_NAMES[0]} ball",
@@ -93,6 +102,7 @@ class ObstructedMazeEnv(RoomGrid):
             room_size=room_size,
             num_rows=num_rows,
             num_cols=num_cols,
+            max_steps=max_steps,
             **kwargs,
         )
         self.obj = Ball()  # initialize the obj attribute, that will be changed later on

--- a/minigrid/envs/obstructedmaze.py
+++ b/minigrid/envs/obstructedmaze.py
@@ -83,7 +83,7 @@ class ObstructedMazeEnv(RoomGrid):
         room_size = 6
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 4 * num_rooms_visited * room_size ** 2
+            kwargs["max_steps"] = 4 * num_rooms_visited * room_size**2
 
         mission_space = MissionSpace(
             mission_func=lambda: f"pick up the {COLOR_NAMES[0]} ball",

--- a/minigrid/envs/playground.py
+++ b/minigrid/envs/playground.py
@@ -11,14 +11,14 @@ class PlaygroundEnv(MiniGridEnv):
     This environment has no specific goals or rewards.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, max_steps=100, **kwargs):
         mission_space = MissionSpace(mission_func=lambda: "")
         self.size = 19
         super().__init__(
             mission_space=mission_space,
             width=self.size,
             height=self.size,
-            max_steps=100,
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/putnear.py
+++ b/minigrid/envs/putnear.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
@@ -65,7 +67,7 @@ class PutNearEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=6, numObjs=2, **kwargs):
+    def __init__(self, size=6, numObjs=2, max_steps: Optional[int] = None, **kwargs):
         self.size = size
         self.numObjs = numObjs
         self.obj_types = ["key", "ball", "box"]
@@ -79,8 +81,8 @@ class PutNearEnv(MiniGridEnv):
             ],
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 5 * size
+        if max_steps is None:
+            max_steps = 5 * size
 
         super().__init__(
             mission_space=mission_space,
@@ -88,6 +90,7 @@ class PutNearEnv(MiniGridEnv):
             height=size,
             # Set this to True for maximum speed
             see_through_walls=True,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/putnear.py
+++ b/minigrid/envs/putnear.py
@@ -78,11 +78,14 @@ class PutNearEnv(MiniGridEnv):
                 self.obj_types,
             ],
         )
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 5 * size
+
         super().__init__(
             mission_space=mission_space,
             width=size,
             height=size,
-            max_steps=5 * size,
             # Set this to True for maximum speed
             see_through_walls=True,
             **kwargs,

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -66,7 +66,7 @@ class RedBlueDoorEnv(MiniGridEnv):
         )
 
         if max_steps is None:
-            max_steps = 20 * size * size
+            max_steps = 20 * size ** 2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Door
@@ -57,17 +59,21 @@ class RedBlueDoorEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, **kwargs):
+    def __init__(self, size=8, max_steps: Optional[int] = None, **kwargs):
         self.size = size
         mission_space = MissionSpace(
             mission_func=lambda: "open the red door then the blue door"
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 20 * size * size
+        if max_steps is None:
+            max_steps = 20 * size * size
 
         super().__init__(
-            mission_space=mission_space, width=2 * size, height=size, **kwargs
+            mission_space=mission_space,
+            width=2 * size,
+            height=size,
+            max_steps=max_steps,
+            **kwargs
         )
 
     def _gen_grid(self, width, height):

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -66,7 +66,7 @@ class RedBlueDoorEnv(MiniGridEnv):
         )
 
         if max_steps is None:
-            max_steps = 20 * size ** 2
+            max_steps = 20 * size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -67,10 +67,7 @@ class RedBlueDoorEnv(MiniGridEnv):
             kwargs["max_steps"] = 20 * size * size
 
         super().__init__(
-            mission_space=mission_space,
-            width=2 * size,
-            height=size,
-            **kwargs
+            mission_space=mission_space, width=2 * size, height=size, **kwargs
         )
 
     def _gen_grid(self, width, height):

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -62,11 +62,14 @@ class RedBlueDoorEnv(MiniGridEnv):
         mission_space = MissionSpace(
             mission_func=lambda: "open the red door then the blue door"
         )
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 20 * size * size
+
         super().__init__(
             mission_space=mission_space,
             width=2 * size,
             height=size,
-            max_steps=20 * size * size,
             **kwargs
         )
 

--- a/minigrid/envs/unlock.py
+++ b/minigrid/envs/unlock.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid
 
@@ -53,18 +55,19 @@ class UnlockEnv(RoomGrid):
 
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, max_steps: Optional[int] = None, **kwargs):
         room_size = 6
         mission_space = MissionSpace(mission_func=lambda: "open the door")
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size**2
+        if max_steps is None:
+            max_steps = 8 * room_size**2
 
         super().__init__(
             mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,
+            max_steps=max_steps,
             **kwargs
         )
 

--- a/minigrid/envs/unlock.py
+++ b/minigrid/envs/unlock.py
@@ -58,7 +58,7 @@ class UnlockEnv(RoomGrid):
         mission_space = MissionSpace(mission_func=lambda: "open the door")
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size ** 2
+            kwargs["max_steps"] = 8 * room_size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/unlock.py
+++ b/minigrid/envs/unlock.py
@@ -56,12 +56,15 @@ class UnlockEnv(RoomGrid):
     def __init__(self, **kwargs):
         room_size = 6
         mission_space = MissionSpace(mission_func=lambda: "open the door")
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 8 * room_size ** 2
+
         super().__init__(
             mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,
-            max_steps=8 * room_size**2,
             **kwargs
         )
 

--- a/minigrid/envs/unlockpickup.py
+++ b/minigrid/envs/unlockpickup.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid
@@ -57,21 +59,22 @@ class UnlockPickupEnv(RoomGrid):
 
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
         room_size = 6
         mission_space = MissionSpace(
             mission_func=lambda color: f"pick up the {color} box",
             ordered_placeholders=[COLOR_NAMES],
         )
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size**2
+        if max_steps is None:
+            max_steps = 8 * room_size**2
 
         super().__init__(
             mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,
+            max_steps=max_steps,
             **kwargs,
         )
 

--- a/minigrid/envs/unlockpickup.py
+++ b/minigrid/envs/unlockpickup.py
@@ -59,7 +59,7 @@ class UnlockPickupEnv(RoomGrid):
 
     """
 
-    def __init__(self,  max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: Optional[int] = None, **kwargs):
         room_size = 6
         mission_space = MissionSpace(
             mission_func=lambda color: f"pick up the {color} box",

--- a/minigrid/envs/unlockpickup.py
+++ b/minigrid/envs/unlockpickup.py
@@ -65,7 +65,7 @@ class UnlockPickupEnv(RoomGrid):
         )
 
         if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 8 * room_size ** 2
+            kwargs["max_steps"] = 8 * room_size**2
 
         super().__init__(
             mission_space=mission_space,

--- a/minigrid/envs/unlockpickup.py
+++ b/minigrid/envs/unlockpickup.py
@@ -63,12 +63,15 @@ class UnlockPickupEnv(RoomGrid):
             mission_func=lambda color: f"pick up the {color} box",
             ordered_placeholders=[COLOR_NAMES],
         )
+
+        if "max_steps" not in kwargs:
+            kwargs["max_steps"] = 8 * room_size ** 2
+
         super().__init__(
             mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,
-            max_steps=8 * room_size**2,
             **kwargs,
         )
 

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -903,7 +903,10 @@ class MiniGridEnv(gym.Env):
         # Environment configuration
         self.width = width
         self.height = height
+        
+        assert isinstance(max_steps, int), f"The argument max_steps must be an integer, got: {type(max_steps)}"
         self.max_steps = max_steps
+
         self.see_through_walls = see_through_walls
 
         # Current position and direction of the agent
@@ -1364,8 +1367,11 @@ class MiniGridEnv(gym.Env):
 
         else:
             raise ValueError(f"Unknown action: {action}")
-
+        
         if self.step_count >= self.max_steps:
+            print('INSIDE STEP FUNCTION')
+            print(self.step_count)
+            print(self.max_steps)
             truncated = True
 
         if self.render_mode == "human":

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -903,8 +903,10 @@ class MiniGridEnv(gym.Env):
         # Environment configuration
         self.width = width
         self.height = height
-        
-        assert isinstance(max_steps, int), f"The argument max_steps must be an integer, got: {type(max_steps)}"
+
+        assert isinstance(
+            max_steps, int
+        ), f"The argument max_steps must be an integer, got: {type(max_steps)}"
         self.max_steps = max_steps
 
         self.see_through_walls = see_through_walls
@@ -1367,9 +1369,9 @@ class MiniGridEnv(gym.Env):
 
         else:
             raise ValueError(f"Unknown action: {action}")
-        
+
         if self.step_count >= self.max_steps:
-            print('INSIDE STEP FUNCTION')
+            print("INSIDE STEP FUNCTION")
             print(self.step_count)
             print(self.max_steps)
             truncated = True

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -1371,9 +1371,6 @@ class MiniGridEnv(gym.Env):
             raise ValueError(f"Unknown action: {action}")
 
         if self.step_count >= self.max_steps:
-            print("INSIDE STEP FUNCTION")
-            print(self.step_count)
-            print(self.max_steps)
             truncated = True
 
         if self.render_mode == "human":

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -143,7 +143,23 @@ def test_agent_sees_method(env_id):
     "env_spec", all_testing_env_specs, ids=[spec.id for spec in all_testing_env_specs]
 )
 def test_max_steps_argument(env_spec):
-    env = env_spec.make(max_steps=50)
+    """
+    Test that when initializing an environment with a fixed number of stpes per episode (`max_steps` argument),
+    the episode will be truncated after that number of episodes
+    """
+    max_steps = 50
+    env = env_spec.make(max_steps=max_steps)
+    env.reset()
+    step_count = 0
+    while True:
+        _, _, terminated, truncated, _ = env.step(4)
+        step_count += 1
+        if truncated:
+            assert step_count == max_steps
+            step_count = 0
+            break
+
+    env.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -144,8 +144,8 @@ def test_agent_sees_method(env_id):
 )
 def test_max_steps_argument(env_spec):
     """
-    Test that when initializing an environment with a fixed number of stpes per episode (`max_steps` argument),
-    the episode will be truncated after that number of episodes
+    Test that when initializing an environment with a fixed number of steps per episode (`max_steps` argument),
+    the episode will be truncated after taking that number of steps.
     """
     max_steps = 50
     env = env_spec.make(max_steps=max_steps)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -142,6 +142,13 @@ def test_agent_sees_method(env_id):
 @pytest.mark.parametrize(
     "env_spec", all_testing_env_specs, ids=[spec.id for spec in all_testing_env_specs]
 )
+def test_max_steps_argument(env_spec):
+    env = env_spec.make(max_steps=50)
+
+
+@pytest.mark.parametrize(
+    "env_spec", all_testing_env_specs, ids=[spec.id for spec in all_testing_env_specs]
+)
 def old_run_test(env_spec):
     # Load the gym environment
     env = env_spec.make()


### PR DESCRIPTION
# Description

This PR allows to pass the argument `max_steps` when initializing any minigrid environment. `max_steps` indicates the number of environment steps before the episode is truncated.

This PR also fixes issue #264

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
