### PR TITLE
Some typing improvements, add py.typed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ __pycache__
 
 # Virtual environments
 .env
+.venv
 venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,5 @@
 ---
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v1.7.7
-    hooks:
-      - id: autoflake
-        args: ["--in-place", "--remove-all-unused-imports", "--ignore-init-module-imports", "--ignore-pass-after-docstring"]
   - repo: https://github.com/python/black
     rev: 22.3.0
     hooks:
@@ -35,8 +25,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-        args: 
-          - --settings-file=pyproject.toml
+        args: ["--profile", "black"]
 #  - repo: https://github.com/pycqa/pydocstyle
 #    rev: 6.1.1
 #    hooks:
@@ -46,6 +35,11 @@ repos:
 #          - --explain
 #          - --convention=google
 #        additional_dependencies: ["toml"]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
   - repo: local
     hooks:
       - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,15 @@
 ---
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v1.7.7
+    hooks:
+      - id: autoflake
+        args: ["--in-place", "--remove-all-unused-imports", "--ignore-init-module-imports", "--ignore-pass-after-docstring"]
   - repo: https://github.com/python/black
     rev: 22.3.0
     hooks:
@@ -36,11 +46,6 @@ repos:
 #          - --explain
 #          - --convention=google
 #        additional_dependencies: ["toml"]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
   - repo: local
     hooks:
       - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,7 @@ repos:
     hooks:
       - id: isort
         args: 
-          - --profile=black
-          - '--add-import="from __future__ import annotations"'
-          - --append-only
+          - --settings-file=pyproject.toml
 #  - repo: https://github.com/pycqa/pydocstyle
 #    rev: 6.1.1
 #    hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,10 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
+        args: 
+          - --profile=black
+          - '--add-import="from __future__ import annotations"'
+          - --append-only
 #  - repo: https://github.com/pycqa/pydocstyle
 #    rev: 6.1.1
 #    hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ html_theme_options = {
     "dark_logo": "img/minigrid-white.svg",
     "gtag": "G-FBXJQQLXKD",
 }
-html_context: Dict[str, Any] = {}
+html_context: dict[str, Any] = {}
 html_context["conf_py_path"] = "/docs/"
 html_context["display_github"] = True
 html_context["github_user"] = "Farama-Foundation"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,8 @@
 # TODO: change to minigrid version
 # from TODO import __version__ as minigrid_version
 
+from __future__ import annotations
+
 import os
 import sys
 from typing import Any, Dict

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any, Dict
+from typing import Any
 
 project = "MiniGrid"
 copyright = "2022"

--- a/docs/scripts/gen_envs_display.py
+++ b/docs/scripts/gen_envs_display.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import gymnasium

--- a/docs/scripts/gen_gifs.py
+++ b/docs/scripts/gen_gifs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 

--- a/docs/scripts/move404.py
+++ b/docs/scripts/move404.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 if __name__ == "__main__":

--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/minigrid/__init__.py
+++ b/minigrid/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gymnasium.envs.registration import register
 
 from minigrid import minigrid_env, wrappers

--- a/minigrid/benchmark.py
+++ b/minigrid/benchmark.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import time
 
 import gymnasium as gym

--- a/minigrid/core/actions.py
+++ b/minigrid/core/actions.py
@@ -1,4 +1,6 @@
 # Enumeration of possible actions
+from __future__ import annotations
+
 from enum import IntEnum
 
 

--- a/minigrid/core/constants.py
+++ b/minigrid/core/constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 TILE_PIXELS = 32

--- a/minigrid/core/grid.py
+++ b/minigrid/core/grid.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import numpy as np
 
@@ -15,13 +15,14 @@ from minigrid.utils.rendering import (
 )
 
 
+
 class Grid:
     """
     Represent a grid and operations on it
     """
 
     # Static cache of pre-renderer tiles
-    tile_cache = {}
+    tile_cache:Dict[Tuple[Any, ...], Any] = {}
 
     def __init__(self, width: int, height: int):
         assert width >= 3
@@ -30,7 +31,7 @@ class Grid:
         self.width: int = width
         self.height: int = height
 
-        self.grid: List[Optional[WorldObj]] = [None] * width * height
+        self.grid: List[Optional[WorldObj]] = [None] * (width * height)
 
     def __contains__(self, key: Any) -> bool:
         if isinstance(key, WorldObj):
@@ -76,7 +77,7 @@ class Grid:
         x: int,
         y: int,
         length: Optional[int] = None,
-        obj_type: Type[WorldObj] = Wall,
+        obj_type: Callable[[], WorldObj] = Wall,
     ):
         if length is None:
             length = self.width - x
@@ -88,7 +89,7 @@ class Grid:
         x: int,
         y: int,
         length: Optional[int] = None,
-        obj_type: Type[WorldObj] = Wall,
+        obj_type: Callable[[], WorldObj] = Wall,
     ):
         if length is None:
             length = self.height - y
@@ -139,7 +140,7 @@ class Grid:
     @classmethod
     def render_tile(
         cls,
-        obj: WorldObj,
+        obj: Optional[WorldObj],
         agent_dir: Optional[int] = None,
         highlight: bool = False,
         tile_size: int = TILE_PIXELS,
@@ -150,7 +151,7 @@ class Grid:
         """
 
         # Hash map lookup key for the cache
-        key = (agent_dir, highlight, tile_size)
+        key: Tuple[Any, ...] = (agent_dir, highlight, tile_size)
         key = obj.encode() + key if obj else key
 
         if key in cls.tile_cache:

--- a/minigrid/core/grid.py
+++ b/minigrid/core/grid.py
@@ -23,7 +23,7 @@ class Grid:
     """
 
     # Static cache of pre-renderer tiles
-    tile_cache: Dict[Tuple[Any, ...], Any] = {}
+    tile_cache: dict[tuple[Any, ...], Any] = {}
 
     def __init__(self, width: int, height: int):
         assert width >= 3
@@ -32,7 +32,7 @@ class Grid:
         self.width: int = width
         self.height: int = height
 
-        self.grid: List[Optional[WorldObj]] = [None] * (width * height)
+        self.grid: list[WorldObj | None] = [None] * (width * height)
 
     def __contains__(self, key: Any) -> bool:
         if isinstance(key, WorldObj):
@@ -49,20 +49,20 @@ class Grid:
                     return True
         return False
 
-    def __eq__(self, other: "Grid") -> bool:
+    def __eq__(self, other: Grid) -> bool:
         grid1 = self.encode()
         grid2 = other.encode()
         return np.array_equal(grid2, grid1)
 
-    def __ne__(self, other: "Grid") -> bool:
+    def __ne__(self, other: Grid) -> bool:
         return not self == other
 
-    def copy(self) -> "Grid":
+    def copy(self) -> Grid:
         from copy import deepcopy
 
         return deepcopy(self)
 
-    def set(self, i: int, j: int, v: Optional[WorldObj]):
+    def set(self, i: int, j: int, v: WorldObj | None):
         assert (
             0 <= i < self.width
         ), f"column index {j} outside of grid of width {self.width}"
@@ -71,7 +71,7 @@ class Grid:
         ), f"row index {j} outside of grid of height {self.height}"
         self.grid[j * self.width + i] = v
 
-    def get(self, i: int, j: int) -> Optional[WorldObj]:
+    def get(self, i: int, j: int) -> WorldObj | None:
         assert 0 <= i < self.width
         assert 0 <= j < self.height
         assert self.grid is not None
@@ -81,7 +81,7 @@ class Grid:
         self,
         x: int,
         y: int,
-        length: Optional[int] = None,
+        length: int | None = None,
         obj_type: Callable[[], WorldObj] = Wall,
     ):
         if length is None:
@@ -93,7 +93,7 @@ class Grid:
         self,
         x: int,
         y: int,
-        length: Optional[int] = None,
+        length: int | None = None,
         obj_type: Callable[[], WorldObj] = Wall,
     ):
         if length is None:
@@ -107,7 +107,7 @@ class Grid:
         self.vert_wall(x, y, h)
         self.vert_wall(x + w - 1, y, h)
 
-    def rotate_left(self) -> "Grid":
+    def rotate_left(self) -> Grid:
         """
         Rotate the grid to the left (counter-clockwise)
         """
@@ -121,7 +121,7 @@ class Grid:
 
         return grid
 
-    def slice(self, topX: int, topY: int, width: int, height: int) -> "Grid":
+    def slice(self, topX: int, topY: int, width: int, height: int) -> Grid:
         """
         Get a subset of the grid
         """
@@ -145,8 +145,8 @@ class Grid:
     @classmethod
     def render_tile(
         cls,
-        obj: Optional[WorldObj],
-        agent_dir: Optional[int] = None,
+        obj: WorldObj | None,
+        agent_dir: int | None = None,
         highlight: bool = False,
         tile_size: int = TILE_PIXELS,
         subdivs: int = 3,
@@ -156,7 +156,7 @@ class Grid:
         """
 
         # Hash map lookup key for the cache
-        key: Tuple[Any, ...] = (agent_dir, highlight, tile_size)
+        key: tuple[Any, ...] = (agent_dir, highlight, tile_size)
         key = obj.encode() + key if obj else key
 
         if key in cls.tile_cache:
@@ -200,9 +200,9 @@ class Grid:
     def render(
         self,
         tile_size: int,
-        agent_pos: Tuple[int, int],
-        agent_dir: Optional[int] = None,
-        highlight_mask: Optional[np.ndarray] = None,
+        agent_pos: tuple[int, int],
+        agent_dir: int | None = None,
+        highlight_mask: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Render this grid at a given scale
@@ -241,7 +241,7 @@ class Grid:
 
         return img
 
-    def encode(self, vis_mask: Optional[np.ndarray] = None) -> np.ndarray:
+    def encode(self, vis_mask: np.ndarray | None = None) -> np.ndarray:
         """
         Produce a compact numpy encoding of the grid
         """
@@ -268,7 +268,7 @@ class Grid:
         return array
 
     @staticmethod
-    def decode(array: np.ndarray) -> Tuple["Grid", np.ndarray]:
+    def decode(array: np.ndarray) -> tuple[Grid, np.ndarray]:
         """
         Decode an array grid encoding back into a grid
         """
@@ -288,7 +288,7 @@ class Grid:
 
         return grid, vis_mask
 
-    def process_vis(self, agent_pos: Tuple[int, int]) -> np.ndarray:
+    def process_vis(self, agent_pos: tuple[int, int]) -> np.ndarray:
         mask = np.zeros(shape=(self.width, self.height), dtype=bool)
 
         mask[agent_pos[0], agent_pos[1]] = True

--- a/minigrid/core/grid.py
+++ b/minigrid/core/grid.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 

--- a/minigrid/core/grid.py
+++ b/minigrid/core/grid.py
@@ -62,8 +62,8 @@ class Grid:
         return deepcopy(self)
 
     def set(self, i: int, j: int, v: Optional[WorldObj]):
-        assert 0 <= i < self.width
-        assert 0 <= j < self.height
+        assert 0 <= i < self.width, f"column index {j} outside of grid of width {self.width}"
+        assert 0 <= j < self.height, f"row index {j} outside of grid of height {self.height}"
         self.grid[j * self.width + i] = v
 
     def get(self, i: int, j: int) -> Optional[WorldObj]:

--- a/minigrid/core/grid.py
+++ b/minigrid/core/grid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from typing import Any, Callable, Dict, List, Optional, Tuple
 

--- a/minigrid/core/grid.py
+++ b/minigrid/core/grid.py
@@ -15,14 +15,13 @@ from minigrid.utils.rendering import (
 )
 
 
-
 class Grid:
     """
     Represent a grid and operations on it
     """
 
     # Static cache of pre-renderer tiles
-    tile_cache:Dict[Tuple[Any, ...], Any] = {}
+    tile_cache: Dict[Tuple[Any, ...], Any] = {}
 
     def __init__(self, width: int, height: int):
         assert width >= 3
@@ -62,8 +61,12 @@ class Grid:
         return deepcopy(self)
 
     def set(self, i: int, j: int, v: Optional[WorldObj]):
-        assert 0 <= i < self.width, f"column index {j} outside of grid of width {self.width}"
-        assert 0 <= j < self.height, f"row index {j} outside of grid of height {self.height}"
+        assert (
+            0 <= i < self.width
+        ), f"column index {j} outside of grid of width {self.width}"
+        assert (
+            0 <= j < self.height
+        ), f"row index {j} outside of grid of height {self.height}"
         self.grid[j * self.width + i] = v
 
     def get(self, i: int, j: int) -> Optional[WorldObj]:

--- a/minigrid/core/grid.py
+++ b/minigrid/core/grid.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable
 
 import numpy as np
 

--- a/minigrid/core/mission.py
+++ b/minigrid/core/mission.py
@@ -28,8 +28,8 @@ class MissionSpace(spaces.Space[str]):
     def __init__(
         self,
         mission_func: Callable[..., str],
-        ordered_placeholders: Optional["list[list[str]]"] = None,
-        seed: Optional[Union[int, seeding.RandomNumberGenerator]] = None,
+        ordered_placeholders: Optional[list[list[str]]] = None,
+        seed: int | seeding.RandomNumberGenerator | None = None,
     ):
         r"""Constructor of :class:`MissionSpace` space.
 

--- a/minigrid/core/mission.py
+++ b/minigrid/core/mission.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Optional, Union
 
 from gymnasium import spaces

--- a/minigrid/core/mission.py
+++ b/minigrid/core/mission.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 from gymnasium import spaces
 from gymnasium.utils import seeding
@@ -28,7 +28,7 @@ class MissionSpace(spaces.Space[str]):
     def __init__(
         self,
         mission_func: Callable[..., str],
-        ordered_placeholders: Optional[list[list[str]]] = None,
+        ordered_placeholders: list[list[str]] | None = None,
         seed: int | seeding.RandomNumberGenerator | None = None,
     ):
         r"""Constructor of :class:`MissionSpace` space.

--- a/minigrid/core/roomgrid.py
+++ b/minigrid/core/roomgrid.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union
-
 import numpy as np
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/core/roomgrid.py
+++ b/minigrid/core/roomgrid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Tuple, Union
 
 import numpy as np

--- a/minigrid/core/roomgrid.py
+++ b/minigrid/core/roomgrid.py
@@ -10,7 +10,7 @@ from minigrid.core.world_object import Ball, Box, Door, Key, WorldObj
 from minigrid.minigrid_env import MiniGridEnv
 
 
-def reject_next_to(env: MiniGridEnv, pos: Tuple[int, int]):
+def reject_next_to(env: MiniGridEnv, pos: tuple[int, int]):
     """
     Function to filter out object positions that are right next to
     the agent's starting point
@@ -23,27 +23,27 @@ def reject_next_to(env: MiniGridEnv, pos: Tuple[int, int]):
 
 
 class Room:
-    def __init__(self, top: Tuple[int, int], size: Tuple[int, int]):
+    def __init__(self, top: tuple[int, int], size: tuple[int, int]):
         # Top-left corner and size (tuples)
         self.top = top
         self.size = size
 
         # List of door objects and door positions
         # Order of the doors is right, down, left, up
-        self.doors: List[Optional[Union[bool, Door]]] = [None] * 4
-        self.door_pos: List[Optional[Tuple[int, int]]] = [None] * 4
+        self.doors: list[bool | Door | None] = [None] * 4
+        self.door_pos: list[tuple[int, int] | None] = [None] * 4
 
         # List of rooms adjacent to this one
         # Order of the neighbors is right, down, left, up
-        self.neighbors: List[Optional[Room]] = [None] * 4
+        self.neighbors: list[Room | None] = [None] * 4
 
         # Indicates if this room is behind a locked door
         self.locked: bool = False
 
         # List of objects contained
-        self.objs: List[WorldObj] = []
+        self.objs: list[WorldObj] = []
 
-    def rand_pos(self, env: MiniGridEnv) -> Tuple[int, int]:
+    def rand_pos(self, env: MiniGridEnv) -> tuple[int, int]:
         topX, topY = self.top
         sizeX, sizeY = self.size
         return env._randPos(topX + 1, topX + sizeX - 1, topY + 1, topY + sizeY - 1)
@@ -182,7 +182,7 @@ class RoomGrid(MiniGridEnv):
 
     def place_in_room(
         self, i: int, j: int, obj: WorldObj
-    ) -> Tuple[WorldObj, Tuple[int, int]]:
+    ) -> tuple[WorldObj, tuple[int, int]]:
         """
         Add an existing object to room (i, j)
         """
@@ -201,9 +201,9 @@ class RoomGrid(MiniGridEnv):
         self,
         i: int,
         j: int,
-        kind: Optional[str] = None,
-        color: Optional[str] = None,
-    ) -> Tuple[WorldObj, Tuple[int, int]]:
+        kind: str | None = None,
+        color: str | None = None,
+    ) -> tuple[WorldObj, tuple[int, int]]:
         """
         Add a new object to room (i, j)
         """
@@ -233,10 +233,10 @@ class RoomGrid(MiniGridEnv):
         self,
         i: int,
         j: int,
-        door_idx: Optional[int] = None,
-        color: Optional[str] = None,
-        locked: Optional[bool] = None,
-    ) -> Tuple[Door, Tuple[int, int]]:
+        door_idx: int | None = None,
+        color: str | None = None,
+        locked: bool | None = None,
+    ) -> tuple[Door, tuple[int, int]]:
         """
         Add a door to a room, connecting it to a neighbor
         """
@@ -313,7 +313,7 @@ class RoomGrid(MiniGridEnv):
         neighbor.doors[(wall_idx + 2) % 4] = True
 
     def place_agent(
-        self, i: Optional[int] = None, j: Optional[int] = None, rand_dir: bool = True
+        self, i: int | None = None, j: int | None = None, rand_dir: bool = True
     ) -> np.ndarray:
         """
         Place the agent in a room
@@ -336,8 +336,8 @@ class RoomGrid(MiniGridEnv):
         return self.agent_pos
 
     def connect_all(
-        self, door_colors: List[str] = COLOR_NAMES, max_itrs: int = 5000
-    ) -> List[Door]:
+        self, door_colors: list[str] = COLOR_NAMES, max_itrs: int = 5000
+    ) -> list[Door]:
         """
         Make sure that all rooms are reachable by the agent from its
         starting position
@@ -397,11 +397,11 @@ class RoomGrid(MiniGridEnv):
 
     def add_distractors(
         self,
-        i: Optional[int] = None,
-        j: Optional[int] = None,
+        i: int | None = None,
+        j: int | None = None,
         num_distractors: int = 10,
         all_unique: bool = True,
-    ) -> List[WorldObj]:
+    ) -> list[WorldObj]:
         """
         Add random objects that can potentially distract/confuse the agent.
         """

--- a/minigrid/core/world_object.py
+++ b/minigrid/core/world_object.py
@@ -38,10 +38,10 @@ class WorldObj:
         self.contains = None
 
         # Initial position of the object
-        self.init_pos: Optional[Point] = None
+        self.init_pos: Point | None = None
 
         # Current position of the object
-        self.cur_pos: Optional[Point] = None
+        self.cur_pos: Point | None = None
 
     def can_overlap(self) -> bool:
         """Can the agent overlap with this?"""
@@ -59,16 +59,16 @@ class WorldObj:
         """Can the agent see behind this object?"""
         return True
 
-    def toggle(self, env: "MiniGridEnv", pos: Tuple[int, int]) -> bool:
+    def toggle(self, env: MiniGridEnv, pos: tuple[int, int]) -> bool:
         """Method to trigger/toggle an action this object performs"""
         return False
 
-    def encode(self) -> Tuple[int, int, int]:
+    def encode(self) -> tuple[int, int, int]:
         """Encode the a description of this object as a 3-tuple of integers"""
         return (OBJECT_TO_IDX[self.type], COLOR_TO_IDX[self.color], 0)
 
     @staticmethod
-    def decode(type_idx: int, color_idx: int, state: int) -> Optional["WorldObj"]:
+    def decode(type_idx: int, color_idx: int, state: int) -> Optional[WorldObj]:
         """Create an object from a 3-tuple state description"""
 
         obj_type = IDX_TO_OBJECT[type_idx]
@@ -271,7 +271,7 @@ class Ball(WorldObj):
 
 
 class Box(WorldObj):
-    def __init__(self, color, contains: Optional[WorldObj] = None):
+    def __init__(self, color, contains: WorldObj | None = None):
         super().__init__("box", color)
         self.contains = contains
 

--- a/minigrid/core/world_object.py
+++ b/minigrid/core/world_object.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np

--- a/minigrid/core/world_object.py
+++ b/minigrid/core/world_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Tuple
 
 import numpy as np
 
@@ -68,7 +68,7 @@ class WorldObj:
         return (OBJECT_TO_IDX[self.type], COLOR_TO_IDX[self.color], 0)
 
     @staticmethod
-    def decode(type_idx: int, color_idx: int, state: int) -> Optional[WorldObj]:
+    def decode(type_idx: int, color_idx: int, state: int) -> WorldObj | None:
         """Create an object from a 3-tuple state description"""
 
         obj_type = IDX_TO_OBJECT[type_idx]

--- a/minigrid/core/world_object.py
+++ b/minigrid/core/world_object.py
@@ -19,6 +19,8 @@ from minigrid.utils.rendering import (
 if TYPE_CHECKING:
     from minigrid.minigrid_env import MiniGridEnv
 
+Point = Tuple[int, int]
+
 
 class WorldObj:
 
@@ -34,10 +36,10 @@ class WorldObj:
         self.contains = None
 
         # Initial position of the object
-        self.init_pos = None
+        self.init_pos: Optional[Point] = None
 
         # Current position of the object
-        self.cur_pos = None
+        self.cur_pos: Optional[Point] = None
 
     def can_overlap(self) -> bool:
         """Can the agent overlap with this?"""

--- a/minigrid/envs/__init__.py
+++ b/minigrid/envs/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from minigrid.envs.blockedunlockpickup import BlockedUnlockPickupEnv
 from minigrid.envs.crossing import CrossingEnv
 from minigrid.envs.distshift import DistShiftEnv

--- a/minigrid/envs/babyai/__init__.py
+++ b/minigrid/envs/babyai/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from minigrid.envs.babyai.goto import (
     GoTo,
     GoToDoor,

--- a/minigrid/envs/babyai/core/levelgen.py
+++ b/minigrid/envs/babyai/core/levelgen.py
@@ -39,7 +39,7 @@ class LevelGen(RoomGridLevel):
         implicit_unlock=True,
         action_kinds=["goto", "pickup", "open", "putnext"],
         instr_kinds=["action", "and", "seq"],
-        **kwargs
+        **kwargs,
     ):
         self.num_dists = num_dists
         self.locked_room_prob = locked_room_prob

--- a/minigrid/envs/babyai/core/levelgen.py
+++ b/minigrid/envs/babyai/core/levelgen.py
@@ -1,6 +1,8 @@
 """
 Copied and adapted from https://github.com/mila-iqia/babyai
 """
+from __future__ import annotations
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.roomgrid import Room
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel

--- a/minigrid/envs/babyai/core/roomgrid_level.py
+++ b/minigrid/envs/babyai/core/roomgrid_level.py
@@ -3,8 +3,6 @@ Copied and adapted from https://github.com/mila-iqia/babyai
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.roomgrid import RoomGrid
 from minigrid.envs.babyai.core.verifier import (
     ActionInstr,

--- a/minigrid/envs/babyai/core/roomgrid_level.py
+++ b/minigrid/envs/babyai/core/roomgrid_level.py
@@ -1,6 +1,8 @@
 """
 Copied and adapted from https://github.com/mila-iqia/babyai
 """
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.roomgrid import RoomGrid

--- a/minigrid/envs/babyai/core/roomgrid_level.py
+++ b/minigrid/envs/babyai/core/roomgrid_level.py
@@ -52,7 +52,7 @@ class RoomGridLevel(RoomGrid):
     of approximately similar difficulty.
     """
 
-    def __init__(self, room_size=8, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, room_size=8, max_steps: int | None = None, **kwargs):
         mission_space = BabyAIMissionSpace()
 
         # If `max_steps` arg is passed it will be fixed for every episode,
@@ -66,7 +66,7 @@ class RoomGridLevel(RoomGrid):
             room_size=room_size,
             mission_space=mission_space,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     def reset(self, **kwargs):

--- a/minigrid/envs/babyai/core/verifier.py
+++ b/minigrid/envs/babyai/core/verifier.py
@@ -1,6 +1,8 @@
 """
 Copied and adapted from https://github.com/mila-iqia/babyai
 """
+from __future__ import annotations
+
 import os
 from abc import ABC, abstractmethod
 

--- a/minigrid/envs/babyai/goto.py
+++ b/minigrid/envs/babyai/goto.py
@@ -108,7 +108,7 @@ class GoTo(RoomGridLevel):
         num_cols=3,
         num_dists=18,
         doors_open=False,
-        **kwargs
+        **kwargs,
     ):
         self.num_dists = num_dists
         self.doors_open = doors_open
@@ -200,7 +200,7 @@ class GoToSeq(LevelGen):
             locked_room_prob=0,
             locations=False,
             unblocking=False,
-            **kwargs
+            **kwargs,
         )
 
 

--- a/minigrid/envs/babyai/goto.py
+++ b/minigrid/envs/babyai/goto.py
@@ -2,6 +2,8 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Go to` instruction.
 """
+from __future__ import annotations
+
 from minigrid.envs.babyai.core.levelgen import LevelGen
 from minigrid.envs.babyai.core.roomgrid_level import RejectSampling, RoomGridLevel
 from minigrid.envs.babyai.core.verifier import GoToInstr, ObjDesc

--- a/minigrid/envs/babyai/open.py
+++ b/minigrid/envs/babyai/open.py
@@ -2,6 +2,8 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Open` instruction.
 """
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/babyai/open.py
+++ b/minigrid/envs/babyai/open.py
@@ -105,8 +105,8 @@ class OpenTwoDoors(RoomGridLevel):
         first_color=None,
         second_color=None,
         strict=False,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         self.first_color = first_color
         self.second_color = second_color
@@ -145,7 +145,7 @@ class OpenDoorsOrder(RoomGridLevel):
     """
 
     def __init__(
-        self, num_doors, debug=False, max_steps: Optional[int] = None, **kwargs
+        self, num_doors, debug=False, max_steps: int | None = None, **kwargs
     ):
         assert num_doors >= 2
         self.num_doors = num_doors

--- a/minigrid/envs/babyai/open.py
+++ b/minigrid/envs/babyai/open.py
@@ -4,8 +4,6 @@ Levels described in the Baby AI ICLR 2019 submission, with the `Open` instructio
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel
 from minigrid.envs.babyai.core.verifier import (
@@ -144,9 +142,7 @@ class OpenDoorsOrder(RoomGridLevel):
     Open one or two doors in the order specified.
     """
 
-    def __init__(
-        self, num_doors, debug=False, max_steps: int | None = None, **kwargs
-    ):
+    def __init__(self, num_doors, debug=False, max_steps: int | None = None, **kwargs):
         assert num_doors >= 2
         self.num_doors = num_doors
         self.debug = debug

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -2,6 +2,8 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with different instructions than those in other files.
 """
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -4,8 +4,6 @@ Levels described in the Baby AI ICLR 2019 submission, with different instruction
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel
 from minigrid.envs.babyai.core.verifier import (
     BeforeInstr,

--- a/minigrid/envs/babyai/other.py
+++ b/minigrid/envs/babyai/other.py
@@ -58,7 +58,7 @@ class FindObjS5(RoomGridLevel):
     This level requires potentially exhaustive exploration
     """
 
-    def __init__(self, room_size=5, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, room_size=5, max_steps: int | None = None, **kwargs):
 
         if max_steps is None:
             max_steps = 20 * room_size**2
@@ -87,8 +87,8 @@ class KeyCorridor(RoomGridLevel):
         num_rows=3,
         obj_type="ball",
         room_size=6,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         self.obj_type = obj_type
 
@@ -145,7 +145,7 @@ class MoveTwoAcross(RoomGridLevel):
     """
 
     def __init__(
-        self, room_size, objs_per_room, max_steps: Optional[int] = None, **kwargs
+        self, room_size, objs_per_room, max_steps: int | None = None, **kwargs
     ):
         assert objs_per_room <= 9
         self.objs_per_room = objs_per_room

--- a/minigrid/envs/babyai/pickup.py
+++ b/minigrid/envs/babyai/pickup.py
@@ -65,7 +65,7 @@ class PickupLoc(LevelGen):
             locked_room_prob=0,
             locations=True,
             unblocking=False,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -104,7 +104,7 @@ class PickupAbove(RoomGridLevel):
     This task requires to use the compass to be solved effectively.
     """
 
-    def __init__(self, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: int | None = None, **kwargs):
         room_size = 6
         if max_steps is None:
             max_steps = 8 * room_size**2

--- a/minigrid/envs/babyai/pickup.py
+++ b/minigrid/envs/babyai/pickup.py
@@ -2,6 +2,8 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Pick up` instruction.
 """
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.envs.babyai.core.levelgen import LevelGen

--- a/minigrid/envs/babyai/pickup.py
+++ b/minigrid/envs/babyai/pickup.py
@@ -4,8 +4,6 @@ Levels described in the Baby AI ICLR 2019 submission, with the `Pick up` instruc
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.envs.babyai.core.levelgen import LevelGen
 from minigrid.envs.babyai.core.roomgrid_level import RejectSampling, RoomGridLevel
 from minigrid.envs.babyai.core.verifier import ObjDesc, PickupInstr

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -4,8 +4,6 @@ Levels described in the Baby AI ICLR 2019 submission, with the `Put Next` instru
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel
 from minigrid.envs.babyai.core.verifier import ObjDesc, PutNextInstr
 

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -2,6 +2,8 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Put Next` instruction.
 """
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -86,6 +86,7 @@ class PutNext(RoomGridLevel):
 
         # If the agent starts off carrying the object
         if self.start_carrying:
+            assert self.obj_a.init_pos is not None
             self.grid.set(*self.obj_a.init_pos, None)
             self.carrying = self.obj_a
 

--- a/minigrid/envs/babyai/putnext.py
+++ b/minigrid/envs/babyai/putnext.py
@@ -43,8 +43,8 @@ class PutNext(RoomGridLevel):
         room_size,
         objs_per_room,
         start_carrying=False,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         assert room_size >= 4
         assert objs_per_room <= 9

--- a/minigrid/envs/babyai/synth.py
+++ b/minigrid/envs/babyai/synth.py
@@ -4,6 +4,8 @@ Levels described in the Baby AI ICLR 2019 submission.
 The instructions are a synthesis of those from `PutNext`, `Open`, `GoTo`, and `Pickup`.
 """
 
+from __future__ import annotations
+
 from minigrid.envs.babyai.core.levelgen import LevelGen
 
 

--- a/minigrid/envs/babyai/synth.py
+++ b/minigrid/envs/babyai/synth.py
@@ -30,7 +30,7 @@ class Synth(LevelGen):
             locations=False,
             unblocking=True,
             implicit_unlock=False,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -55,7 +55,7 @@ class SynthLoc(LevelGen):
             locations=True,
             unblocking=True,
             implicit_unlock=False,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -83,7 +83,7 @@ class MiniBossLevel(LevelGen):
             room_size=5,
             num_dists=7,
             locked_room_prob=0.25,
-            **kwargs
+            **kwargs,
         )
 
 

--- a/minigrid/envs/babyai/unlock.py
+++ b/minigrid/envs/babyai/unlock.py
@@ -4,8 +4,6 @@ Levels described in the Baby AI ICLR 2019 submission, with the `Unlock` instruct
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.world_object import Ball, Box, Key
 from minigrid.envs.babyai.core.roomgrid_level import RoomGridLevel

--- a/minigrid/envs/babyai/unlock.py
+++ b/minigrid/envs/babyai/unlock.py
@@ -2,6 +2,8 @@
 Copied and adapted from https://github.com/mila-iqia/babyai.
 Levels described in the Baby AI ICLR 2019 submission, with the `Unlock` instruction.
 """
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/babyai/unlock.py
+++ b/minigrid/envs/babyai/unlock.py
@@ -112,7 +112,7 @@ class UnlockPickup(RoomGridLevel):
     Unlock a door, then pick up a box in another room
     """
 
-    def __init__(self, distractors=False, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, distractors=False, max_steps: int | None = None, **kwargs):
         self.distractors = distractors
         room_size = 6
         if max is None:
@@ -143,7 +143,7 @@ class BlockedUnlockPickup(RoomGridLevel):
     in another room
     """
 
-    def __init__(self, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: int | None = None, **kwargs):
         room_size = 6
         if max_steps is None:
             max_steps = 16 * room_size**2
@@ -173,7 +173,7 @@ class UnlockToUnlock(RoomGridLevel):
     Unlock a door A that requires to unlock a door B before
     """
 
-    def __init__(self, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: int | None = None, **kwargs):
         room_size = 6
         if max_steps is None:
             max_steps = 30 * room_size**2

--- a/minigrid/envs/blockedunlockpickup.py
+++ b/minigrid/envs/blockedunlockpickup.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid

--- a/minigrid/envs/blockedunlockpickup.py
+++ b/minigrid/envs/blockedunlockpickup.py
@@ -66,7 +66,7 @@ class BlockedUnlockPickupEnv(RoomGrid):
 
     """
 
-    def __init__(self, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: int | None = None, **kwargs):
         mission_space = MissionSpace(
             mission_func=self._gen_mission,
             ordered_placeholders=[COLOR_NAMES, ["box", "key"]],

--- a/minigrid/envs/blockedunlockpickup.py
+++ b/minigrid/envs/blockedunlockpickup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools as itt
 from typing import Optional
 

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools as itt
-from typing import Optional
 
 import numpy as np
 

--- a/minigrid/envs/crossing.py
+++ b/minigrid/envs/crossing.py
@@ -90,8 +90,8 @@ class CrossingEnv(MiniGridEnv):
         size=9,
         num_crossings=1,
         obstacle_type=Lava,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         self.num_crossings = num_crossings
         self.obstacle_type = obstacle_type
@@ -109,7 +109,7 @@ class CrossingEnv(MiniGridEnv):
             grid_size=size,
             see_through_walls=False,  # Set this to True for maximum speed
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/distshift.py
+++ b/minigrid/envs/distshift.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.grid import Grid

--- a/minigrid/envs/distshift.py
+++ b/minigrid/envs/distshift.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Goal, Lava

--- a/minigrid/envs/distshift.py
+++ b/minigrid/envs/distshift.py
@@ -71,8 +71,8 @@ class DistShiftEnv(MiniGridEnv):
         agent_start_pos=(1, 1),
         agent_start_dir=0,
         strip2_row=2,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -91,7 +91,7 @@ class DistShiftEnv(MiniGridEnv):
             # Set this to True for maximum speed
             see_through_walls=True,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Door, Goal, Key

--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.grid import Grid

--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -62,7 +62,7 @@ class DoorKeyEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, size=8, max_steps: int | None = None, **kwargs):
         if max_steps is None:
             max_steps = 10 * size**2
         mission_space = MissionSpace(mission_func=self._gen_mission)

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from operator import add
 from typing import Optional
 

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -76,8 +76,8 @@ class DynamicObstaclesEnv(MiniGridEnv):
         agent_start_pos=(1, 1),
         agent_start_dir=0,
         n_obstacles=4,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -99,7 +99,7 @@ class DynamicObstaclesEnv(MiniGridEnv):
             # Set this to True for maximum speed
             see_through_walls=True,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
         # Allow only 3 actions permitted: left, right, forward
         self.action_space = Discrete(self.actions.forward + 1)

--- a/minigrid/envs/dynamicobstacles.py
+++ b/minigrid/envs/dynamicobstacles.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from operator import add
-from typing import Optional
 
 from gymnasium.spaces import Discrete
 

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Goal

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.grid import Grid

--- a/minigrid/envs/empty.py
+++ b/minigrid/envs/empty.py
@@ -72,8 +72,8 @@ class EmptyEnv(MiniGridEnv):
         size=8,
         agent_start_pos=(1, 1),
         agent_start_dir=0,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -89,7 +89,7 @@ class EmptyEnv(MiniGridEnv):
             # Set this to True for maximum speed
             see_through_walls=True,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/fetch.py
+++ b/minigrid/envs/fetch.py
@@ -73,7 +73,7 @@ class FetchEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, numObjs=3, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, size=8, numObjs=3, max_steps: int | None = None, **kwargs):
         self.numObjs = numObjs
         self.obj_types = ["key", "ball"]
 

--- a/minigrid/envs/fetch.py
+++ b/minigrid/envs/fetch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/fetch.py
+++ b/minigrid/envs/fetch.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/fourrooms.py
+++ b/minigrid/envs/fourrooms.py
@@ -69,7 +69,7 @@ class FourRoomsEnv(MiniGridEnv):
             width=self.size,
             height=self.size,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/fourrooms.py
+++ b/minigrid/envs/fourrooms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Goal

--- a/minigrid/envs/gotodoor.py
+++ b/minigrid/envs/gotodoor.py
@@ -65,7 +65,7 @@ class GoToDoorEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=5, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, size=5, max_steps: int | None = None, **kwargs):
         assert size >= 5
         self.size = size
         mission_space = MissionSpace(

--- a/minigrid/envs/gotodoor.py
+++ b/minigrid/envs/gotodoor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/gotodoor.py
+++ b/minigrid/envs/gotodoor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/gotoobject.py
+++ b/minigrid/envs/gotoobject.py
@@ -15,7 +15,7 @@ class GoToObjectEnv(MiniGridEnv):
     named using an English text string
     """
 
-    def __init__(self, size=6, numObjs=2, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, size=6, numObjs=2, max_steps: int | None = None, **kwargs):
 
         self.numObjs = numObjs
         self.size = size

--- a/minigrid/envs/gotoobject.py
+++ b/minigrid/envs/gotoobject.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/gotoobject.py
+++ b/minigrid/envs/gotoobject.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/keycorridor.py
+++ b/minigrid/envs/keycorridor.py
@@ -79,7 +79,7 @@ class KeyCorridorEnv(RoomGrid):
         num_rows=3,
         obj_type="ball",
         room_size=6,
-        max_steps: Optional[int] = None,
+        max_steps: int | None = None,
         **kwargs,
     ):
         self.obj_type = obj_type

--- a/minigrid/envs/keycorridor.py
+++ b/minigrid/envs/keycorridor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid

--- a/minigrid/envs/keycorridor.py
+++ b/minigrid/envs/keycorridor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/lavagap.py
+++ b/minigrid/envs/lavagap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/minigrid/envs/lavagap.py
+++ b/minigrid/envs/lavagap.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 
 from minigrid.core.grid import Grid

--- a/minigrid/envs/lavagap.py
+++ b/minigrid/envs/lavagap.py
@@ -69,7 +69,7 @@ class LavaGapEnv(MiniGridEnv):
     """
 
     def __init__(
-        self, size, obstacle_type=Lava, max_steps: Optional[int] = None, **kwargs
+        self, size, obstacle_type=Lava, max_steps: int | None = None, **kwargs
     ):
         self.obstacle_type = obstacle_type
         self.size = size
@@ -89,7 +89,7 @@ class LavaGapEnv(MiniGridEnv):
             # Set this to True for maximum speed
             see_through_walls=False,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/lockedroom.py
+++ b/minigrid/envs/lockedroom.py
@@ -78,7 +78,7 @@ class LockedRoomEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=19, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, size=19, max_steps: int | None = None, **kwargs):
         self.size = size
 
         if max_steps is None:

--- a/minigrid/envs/lockedroom.py
+++ b/minigrid/envs/lockedroom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/lockedroom.py
+++ b/minigrid/envs/lockedroom.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/memory.py
+++ b/minigrid/envs/memory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/minigrid/envs/memory.py
+++ b/minigrid/envs/memory.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 
 from minigrid.core.actions import Actions

--- a/minigrid/envs/memory.py
+++ b/minigrid/envs/memory.py
@@ -70,7 +70,7 @@ class MemoryEnv(MiniGridEnv):
     """
 
     def __init__(
-        self, size=8, random_length=False, max_steps: Optional[int] = None, **kwargs
+        self, size=8, random_length=False, max_steps: int | None = None, **kwargs
     ):
         self.size = size
         self.random_length = random_length
@@ -86,7 +86,7 @@ class MemoryEnv(MiniGridEnv):
             # Set this to True for maximum speed
             see_through_walls=False,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/multiroom.py
+++ b/minigrid/envs/multiroom.py
@@ -79,8 +79,8 @@ class MultiRoomEnv(MiniGridEnv):
         minNumRooms,
         maxNumRooms,
         maxRoomSize=10,
-        max_steps: Optional[int] = None,
-        **kwargs
+        max_steps: int | None = None,
+        **kwargs,
     ):
         assert minNumRooms > 0
         assert maxNumRooms >= minNumRooms
@@ -104,7 +104,7 @@ class MultiRoomEnv(MiniGridEnv):
             width=self.size,
             height=self.size,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/multiroom.py
+++ b/minigrid/envs/multiroom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/multiroom.py
+++ b/minigrid/envs/multiroom.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/obstructedmaze.py
+++ b/minigrid/envs/obstructedmaze.py
@@ -78,7 +78,7 @@ class ObstructedMazeEnv(RoomGrid):
         num_rows,
         num_cols,
         num_rooms_visited,
-        max_steps: Optional[int] = None,
+        max_steps: int | None = None,
         **kwargs,
     ):
         room_size = 6

--- a/minigrid/envs/obstructedmaze.py
+++ b/minigrid/envs/obstructedmaze.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES, DIR_TO_VEC

--- a/minigrid/envs/obstructedmaze.py
+++ b/minigrid/envs/obstructedmaze.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES, DIR_TO_VEC
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid

--- a/minigrid/envs/playground.py
+++ b/minigrid/envs/playground.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/playground.py
+++ b/minigrid/envs/playground.py
@@ -21,7 +21,7 @@ class PlaygroundEnv(MiniGridEnv):
             width=self.size,
             height=self.size,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/putnear.py
+++ b/minigrid/envs/putnear.py
@@ -69,7 +69,7 @@ class PutNearEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=6, numObjs=2, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, size=6, numObjs=2, max_steps: int | None = None, **kwargs):
         self.size = size
         self.numObjs = numObjs
         self.obj_types = ["key", "ball", "box"]

--- a/minigrid/envs/putnear.py
+++ b/minigrid/envs/putnear.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/envs/putnear.py
+++ b/minigrid/envs/putnear.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.grid import Grid
 from minigrid.core.mission import MissionSpace
 from minigrid.core.world_object import Door

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.grid import Grid

--- a/minigrid/envs/redbluedoors.py
+++ b/minigrid/envs/redbluedoors.py
@@ -61,7 +61,7 @@ class RedBlueDoorEnv(MiniGridEnv):
 
     """
 
-    def __init__(self, size=8, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, size=8, max_steps: int | None = None, **kwargs):
         self.size = size
         mission_space = MissionSpace(mission_func=self._gen_mission)
 

--- a/minigrid/envs/unlock.py
+++ b/minigrid/envs/unlock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.mission import MissionSpace

--- a/minigrid/envs/unlock.py
+++ b/minigrid/envs/unlock.py
@@ -55,7 +55,7 @@ class UnlockEnv(RoomGrid):
 
     """
 
-    def __init__(self, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: int | None = None, **kwargs):
         room_size = 6
         mission_space = MissionSpace(mission_func=self._gen_mission)
 
@@ -68,7 +68,7 @@ class UnlockEnv(RoomGrid):
             num_cols=2,
             room_size=room_size,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod

--- a/minigrid/envs/unlock.py
+++ b/minigrid/envs/unlock.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid
 

--- a/minigrid/envs/unlockpickup.py
+++ b/minigrid/envs/unlockpickup.py
@@ -59,7 +59,7 @@ class UnlockPickupEnv(RoomGrid):
 
     """
 
-    def __init__(self, max_steps: Optional[int] = None, **kwargs):
+    def __init__(self, max_steps: int | None = None, **kwargs):
         room_size = 6
         mission_space = MissionSpace(
             mission_func=self._gen_mission,

--- a/minigrid/envs/unlockpickup.py
+++ b/minigrid/envs/unlockpickup.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from minigrid.core.constants import COLOR_NAMES
 from minigrid.core.mission import MissionSpace
 from minigrid.core.roomgrid import RoomGrid

--- a/minigrid/envs/unlockpickup.py
+++ b/minigrid/envs/unlockpickup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from minigrid.core.constants import COLOR_NAMES

--- a/minigrid/manual_control.py
+++ b/minigrid/manual_control.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import gymnasium as gym
 
 from minigrid.minigrid_env import MiniGridEnv

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -2,7 +2,7 @@ import hashlib
 import math
 from abc import abstractmethod
 from enum import IntEnum
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import gymnasium as gym
 import numpy as np
@@ -10,6 +10,7 @@ from gymnasium import spaces
 
 from minigrid.core.constants import COLOR_NAMES, DIR_TO_VEC, TILE_PIXELS
 from minigrid.core.grid import Grid
+from minigrid.core.world_object import WorldObj, Point
 from minigrid.core.mission import MissionSpace
 from minigrid.utils.window import Window
 
@@ -43,9 +44,9 @@ class MiniGridEnv(gym.Env):
     def __init__(
         self,
         mission_space: MissionSpace,
-        grid_size: int = None,
-        width: int = None,
-        height: int = None,
+        grid_size: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
         max_steps: int = 100,
         see_through_walls: bool = False,
         agent_view_size: int = 7,
@@ -62,6 +63,7 @@ class MiniGridEnv(gym.Env):
             assert width is None and height is None
             width = grid_size
             height = grid_size
+        assert width is not None and height is not None
 
         # Action enumeration for this environment
         self.actions = MiniGridEnv.Actions
@@ -107,7 +109,7 @@ class MiniGridEnv(gym.Env):
         self.see_through_walls = see_through_walls
 
         # Current position and direction of the agent
-        self.agent_pos: np.ndarray = None
+        self.agent_pos: Union[np.ndarray, Tuple[int, int]] = None
         self.agent_dir: int = None
 
         # Current grid and mission and carrying
@@ -299,7 +301,14 @@ class MiniGridEnv(gym.Env):
             self.np_random.integers(yLow, yHigh),
         )
 
-    def place_obj(self, obj, top=None, size=None, reject_fn=None, max_tries=math.inf):
+    def place_obj(
+        self,
+        obj: Optional[WorldObj],
+        top: Point = None,
+        size: Tuple[int, int] = None,
+        reject_fn=None,
+        max_tries=math.inf,
+    ):
         """
         Place an object at an empty position in the grid
 
@@ -357,7 +366,7 @@ class MiniGridEnv(gym.Env):
 
         return pos
 
-    def put_obj(self, obj, i, j):
+    def put_obj(self, obj: WorldObj, i: int, j: int):
         """
         Put an object at a specific position in the grid
         """

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -10,8 +10,8 @@ from gymnasium import spaces
 
 from minigrid.core.constants import COLOR_NAMES, DIR_TO_VEC, TILE_PIXELS
 from minigrid.core.grid import Grid
-from minigrid.core.world_object import WorldObj, Point
 from minigrid.core.mission import MissionSpace
+from minigrid.core.world_object import Point, WorldObj
 from minigrid.utils.window import Window
 
 T = TypeVar("T")
@@ -103,7 +103,9 @@ class MiniGridEnv(gym.Env):
         self.width = width
         self.height = height
 
-        assert isinstance(max_steps, int), f"The argument max_steps must be an integer, got: {type(max_steps)}"
+        assert isinstance(
+            max_steps, int
+        ), f"The argument max_steps must be an integer, got: {type(max_steps)}"
         self.max_steps = max_steps
 
         self.see_through_walls = see_through_walls
@@ -293,7 +295,9 @@ class MiniGridEnv(gym.Env):
 
         return self._rand_elem(COLOR_NAMES)
 
-    def _rand_pos(self, x_low: int, x_high: int, y_low: int, y_high: int) -> Tuple[int, int]:
+    def _rand_pos(
+        self, x_low: int, x_high: int, y_low: int, y_high: int
+    ) -> Tuple[int, int]:
         """
         Generate a random (x,y) position tuple
         """
@@ -605,7 +609,9 @@ class MiniGridEnv(gym.Env):
         # Process occluders and visibility
         # Note that this incurs some performance cost
         if not self.see_through_walls:
-            vis_mask = grid.process_vis(agent_pos=(agent_view_size // 2, agent_view_size - 1))
+            vis_mask = grid.process_vis(
+                agent_pos=(agent_view_size // 2, agent_view_size - 1)
+            )
         else:
             vis_mask = np.ones(shape=(grid.width, grid.height), dtype=bool)
 
@@ -665,7 +671,11 @@ class MiniGridEnv(gym.Env):
         # of the agent's view area
         f_vec = self.dir_vec
         r_vec = self.right_vec
-        top_left = self.agent_pos + f_vec * (self.agent_view_size - 1) - r_vec * (self.agent_view_size // 2)
+        top_left = (
+            self.agent_pos
+            + f_vec * (self.agent_view_size - 1)
+            - r_vec * (self.agent_view_size // 2)
+        )
 
         # Mask of which cells to highlight
         highlight_mask = np.zeros(shape=(self.width, self.height), dtype=bool)

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -2,7 +2,7 @@ import hashlib
 import math
 from abc import abstractmethod
 from enum import IntEnum
-from typing import Iterable, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Iterable, List, Optional, Tuple, TypeVar, Union
 
 import gymnasium as gym
 import numpy as np

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -134,8 +134,6 @@ class MiniGridEnv(gym.Env):
         # Generate a new random grid at the start of each episode
         self._gen_grid(self.width, self.height)
 
-        assert isinstance(self.agent_pos, tuple)
-
         # These fields should be defined by _gen_grid
         assert (
             self.agent_pos >= (0, 0)

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import math
 from abc import abstractmethod

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -4,7 +4,7 @@ import hashlib
 import math
 from abc import abstractmethod
 from enum import IntEnum
-from typing import Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import Iterable, TypeVar
 
 import gymnasium as gym
 import numpy as np

--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -48,13 +48,13 @@ class MiniGridEnv(gym.Env):
     def __init__(
         self,
         mission_space: MissionSpace,
-        grid_size: Optional[int] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        grid_size: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
         max_steps: int = 100,
         see_through_walls: bool = False,
         agent_view_size: int = 7,
-        render_mode: Optional[str] = None,
+        render_mode: str | None = None,
         highlight: bool = True,
         tile_size: int = TILE_PIXELS,
         agent_pov: bool = False,
@@ -113,7 +113,7 @@ class MiniGridEnv(gym.Env):
         self.see_through_walls = see_through_walls
 
         # Current position and direction of the agent
-        self.agent_pos: Union[np.ndarray, Tuple[int, int]] = None
+        self.agent_pos: np.ndarray | tuple[int, int] = None
         self.agent_dir: int = None
 
         # Current grid and mission and carrying
@@ -271,7 +271,7 @@ class MiniGridEnv(gym.Env):
         idx = self._rand_int(0, len(lst))
         return lst[idx]
 
-    def _rand_subset(self, iterable: Iterable[T], num_elems: int) -> List[T]:
+    def _rand_subset(self, iterable: Iterable[T], num_elems: int) -> list[T]:
         """
         Sample a random subset of distinct elements of a list
         """
@@ -279,7 +279,7 @@ class MiniGridEnv(gym.Env):
         lst = list(iterable)
         assert num_elems <= len(lst)
 
-        out: List[T] = []
+        out: list[T] = []
 
         while len(out) < num_elems:
             elem = self._rand_elem(lst)
@@ -297,7 +297,7 @@ class MiniGridEnv(gym.Env):
 
     def _rand_pos(
         self, x_low: int, x_high: int, y_low: int, y_high: int
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """
         Generate a random (x,y) position tuple
         """
@@ -309,9 +309,9 @@ class MiniGridEnv(gym.Env):
 
     def place_obj(
         self,
-        obj: Optional[WorldObj],
+        obj: WorldObj | None,
         top: Point = None,
-        size: Tuple[int, int] = None,
+        size: tuple[int, int] = None,
         reject_fn=None,
         max_tries=math.inf,
     ):

--- a/minigrid/utils/rendering.py
+++ b/minigrid/utils/rendering.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import numpy as np

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import operator
 from functools import reduce

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,8 @@ reportPrivateImportUsage = "none"
 
 [tool.pytest.ini_options]
 filterwarnings = ['ignore:.*step API.*:DeprecationWarning'] # TODO: to be removed when old step API is removed
+
+[tool.isort]
+profile = "black"
+add_imports = [ "from __future__ import annotations" ]
+append_only = true

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 """Setups up the Minigrid module."""
 
-from __future__ import annotations
-
 from setuptools import find_packages, setup
 
 
@@ -53,7 +51,7 @@ version = get_version()
 header_count, long_description = get_description()
 
 setup(
-    name="minigrid",
+    name="Minigrid",
     version=version,
     author="Farama Foundation",
     author_email="contact@farama.org",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ version = get_version()
 header_count, long_description = get_description()
 
 setup(
-    name="Minigrid",
+    name="minigrid",
     version=version,
     author="Farama Foundation",
     author_email="contact@farama.org",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 """Setups up the Minigrid module."""
 
+from __future__ import annotations
+
 from setuptools import find_packages, setup
 
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 import warnings
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gymnasium as gym
 import numpy as np
 from pytest_mock import MockerFixture

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import gymnasium as gym

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
 """Finds all the specs that we can test with"""
+from __future__ import annotations
+
 import gymnasium as gym
 import numpy as np
 


### PR DESCRIPTION
# Description

* Improves some method typing for the `MinigridEnv` api and elsewhere.
* Adds a `py.typed` marker so that tooling like mypy will know to use minigrid's type annotations.
* Changed name in `setup.py` to `minigrid`

I did not find a `CONTRIBUTING.md` but did `pre-commit` and ensured all tests pass.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
 