### PR TITLE
Order placeholders bug fix

### DIFF
--- a/minigrid/core/mission.py
+++ b/minigrid/core/mission.py
@@ -172,14 +172,14 @@ class MissionSpace(spaces.Space[str]):
             # Check that place holder lists are the same
             if self.ordered_placeholders is not None:
                 # Check length
-                if (len(self.order_placeholder) == len(other.order_placeholder)) and (
+                if (len(self.ordered_placeholders) == len(other.ordered_placeholders)) and (
                     all(
                         set(i) == set(j)
-                        for i, j in zip(self.order_placeholder, other.order_placeholder)
+                        for i, j in zip(self.ordered_placeholders, other.ordered_placeholders)
                     )
                 ):
                     # Check mission string is the same with dummy space placeholders
-                    test_placeholders = [""] * len(self.order_placeholder)
+                    test_placeholders = [""] * len(self.ordered_placeholders)
                     mission = self.mission_func(*test_placeholders)
                     other_mission = other.mission_func(*test_placeholders)
                     return mission == other_mission

--- a/minigrid/core/mission.py
+++ b/minigrid/core/mission.py
@@ -172,10 +172,14 @@ class MissionSpace(spaces.Space[str]):
             # Check that place holder lists are the same
             if self.ordered_placeholders is not None:
                 # Check length
-                if (len(self.ordered_placeholders) == len(other.ordered_placeholders)) and (
+                if (
+                    len(self.ordered_placeholders) == len(other.ordered_placeholders)
+                ) and (
                     all(
                         set(i) == set(j)
-                        for i, j in zip(self.ordered_placeholders, other.ordered_placeholders)
+                        for i, j in zip(
+                            self.ordered_placeholders, other.ordered_placeholders
+                        )
                     )
                 ):
                     # Check mission string is the same with dummy space placeholders

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -303,3 +303,19 @@ def test_mission_space():
 
     assert mission_space.contains("get the green key and the green key.")
     assert mission_space.contains("go fetch the red ball and the green key.")
+
+# not reasonable to test for all environments, test for a few of them.
+@pytest.mark.parametrize("env_id", ["MiniGrid-Empty-8x8-v0", "MiniGrid-DoorKey-16x16-v0","MiniGrid-ObstructedMaze-1Dl-v0"])
+def test_env_sync_vectorization(env_id):
+    
+    def env_maker(env_id, **kwargs):
+        def env_func():
+            env = gym.make(env_id, **kwargs)
+            return env
+        return env_func
+
+    num_envs = 4
+    env = gym.vector.SyncVectorEnv([env_maker(env_id) for _ in range(num_envs)])
+    env.reset()
+    env.step(env.action_space.sample())
+    env.close()


### PR DESCRIPTION
# Description

Fixes `self.order_placeholders` to `self.ordered_placeholders` in `MissionSpace.__eq__`
Fixes #303 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Not needed.

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Since it's a simple spelling mistake, it's not necessary to comment, edit documentation, or add or modify any tests. 