### PR TITLE
fix entry point typo

### DIFF
--- a/minigrid/__init__.py
+++ b/minigrid/__init__.py
@@ -65,7 +65,7 @@ def register_minigrid_envs():
 
     register(
         id="MiniGrid-SimpleCrossingS11N5-v0",
-        entry_point="gym_minigrid.envs:CrossingEnv",
+        entry_point="minigrid.envs:CrossingEnv",
         kwargs={"size": 11, "num_crossings": 5, "obstacle_type": Wall},
     )
 


### PR DESCRIPTION
# Description

Environment register "MiniGrid-SimpleCrossingS11N5-v0" had an entrypoint "gym_minigrid.envs:CrossingEnv" instead of minigrid.envs:CrossingEnv. It wasn't being picked up on in the tests since the utils used a string match on the entrypoint itself so wasn't checking if this env would render. The current value leads to an error if gym_minigrid (old package) is not installed. 

Fixes (a bug I found myself)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

I'd write a test but one exists. I can't think of a nice way to test this but a search on the code base for gym_minigrid now turns up empty. 