### PR TITLE
updated Doorkey 6x6 to corret size

### DIFF
--- a/minigrid/__init__.py
+++ b/minigrid/__init__.py
@@ -96,7 +96,7 @@ def register_minigrid_envs():
     register(
         id="MiniGrid-DoorKey-6x6-v0",
         entry_point="minigrid.envs:DoorKeyEnv",
-        kwargs={"size": 5},
+        kwargs={"size": 6},
     )
 
     register(


### PR DESCRIPTION
# Description

I noticed that the doorkey env 6v6 is actually the same as the 5v5. seems that the register call has the wrong parameter.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


