### PR TITLE
fix unintended observation space size change

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -452,15 +452,9 @@ class DictObservationSpaceWrapper(ObservationWrapper):
         self.max_words_in_mission = max_words_in_mission
         self.word_dict = word_dict
 
-        image_observation_space = spaces.Box(
-            low=0,
-            high=255,
-            shape=(self.agent_view_size, self.agent_view_size, 3),
-            dtype="uint8",
-        )
         self.observation_space = spaces.Dict(
             {
-                "image": image_observation_space,
+                "image": env.observation_space["image"],
                 "direction": spaces.Discrete(4),
                 "mission": spaces.MultiDiscrete(
                     [len(self.word_dict.keys())] * max_words_in_mission

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -327,3 +327,14 @@ def test_symbolic_obs_wrapper(env_id):
         == np.array([goal_pos[0], goal_pos[1], OBJECT_TO_IDX["goal"]])
     )
     env.close()
+
+
+def test_dict_observation_space_doesnt_clash_with_one_hot():
+    env = gym.make("MiniGrid-Empty-5x5-v0")
+    env = OneHotPartialObsWrapper(env)
+    env = DictObservationSpaceWrapper(env)
+    env.reset()
+    obs, _, _, _, _ = env.step(0)
+    assert obs["image"].shape == (7, 7, 20)
+    assert env.observation_space["image"].shape == (7, 7, 20)
+    env.close()


### PR DESCRIPTION
# Description

DictObservationSpaceWrapper was setting the image observation space which clashed with OneHotPartialObsWrapper.

Fixes (haven't created one)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

