### PR TITLE
NoDeath wrapper

### DIFF
--- a/docs/api/wrappers.md
+++ b/docs/api/wrappers.md
@@ -75,3 +75,9 @@ lastpage:
 ```{eval-rst}
 .. autoclass:: minigrid.wrappers.ViewSizeWrapper
 ```
+
+# NoDeath
+
+```{eval-rst}
+.. autoclass:: minigrid.wrappers.NoDeath
+```

--- a/docs/api/wrappers.md
+++ b/docs/api/wrappers.md
@@ -34,6 +34,12 @@ lastpage:
 .. autoclass:: minigrid.wrappers.FullyObsWrapper
 ```
 
+# No Death
+
+```{eval-rst}
+.. autoclass:: minigrid.wrappers.NoDeath
+```
+
 # Observation
 
 ```{eval-rst}
@@ -74,10 +80,4 @@ lastpage:
 
 ```{eval-rst}
 .. autoclass:: minigrid.wrappers.ViewSizeWrapper
-```
-
-# NoDeath
-
-```{eval-rst}
-.. autoclass:: minigrid.wrappers.NoDeath
 ```

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -811,7 +811,7 @@ class NoDeath(Wrapper):
         >>> _, _, _, _, _ = env.step(1)
         >>> _, reward, term, *_ = env.step(2)
         >>> reward, term
-        (-1, False)
+        (-1.0, False)
         >>>
         >>>
         >>> env = gym.make("MiniGrid-Dynamic-Obstacles-5x5-v0")
@@ -824,7 +824,7 @@ class NoDeath(Wrapper):
         >>> _, _ = env.reset(seed=2)
         >>> _, reward, term, *_ = env.step(2)
         >>> reward, term
-        (-2, False)
+        (-2.0, False)
     """
 
     def __init__(self, env, no_death_types: tuple[str, ...], death_cost: float = -1.0):

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -847,9 +847,9 @@ class NoDeath(Wrapper):
         # so we need to check for collision before self.env.step()
         front_cell = self.grid.get(*self.front_pos)
         going_to_death = (
-            action == self.actions.forward and
-            front_cell is not None and
-            front_cell.type in self.no_death_types
+            action == self.actions.forward
+            and front_cell is not None
+            and front_cell.type in self.no_death_types
         )
 
         obs, reward, terminated, truncated, info = self.env.step(action)
@@ -857,10 +857,7 @@ class NoDeath(Wrapper):
         # We also check if the agent stays in death cells (e.g., lava)
         # without moving
         current_cell = self.grid.get(*self.agent_pos)
-        in_death = (
-            current_cell is not None and
-            current_cell.type in self.no_death_types
-        )
+        in_death = current_cell is not None and current_cell.type in self.no_death_types
 
         if terminated and (going_to_death or in_death):
             terminated = False

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -788,3 +788,82 @@ class StochasticActionWrapper(ActionWrapper):
                 return self.np_random.integers(0, high=6)
             else:
                 return self.random_action
+
+
+class NoDeath(Wrapper):
+    """
+    Wrapper to prevent death in specific cells (e.g., lava cells).
+    Instead of dying, the agent will receive a negative reward.
+
+    Example:
+        >>> import gymnasium as gym
+        >>> from minigrid.wrappers import NoDeath
+        >>>
+        >>> env = gym.make("MiniGrid-LavaCrossingS9N1-v0")
+        >>> _, _ = env.reset(seed=2)
+        >>> _, _, _, _, _ = env.step(1)
+        >>> _, reward, term, *_ = env.step(2)
+        >>> reward, term
+        (0, True)
+        >>>
+        >>> env = NoDeath(env, ["lava"], -1)
+        >>> _, _ = env.reset(seed=2)
+        >>> _, _, _, _, _ = env.step(1)
+        >>> _, reward, term, *_ = env.step(2)
+        >>> reward, term
+        (-1, False)
+        >>>
+        >>>
+        >>> env = gym.make("MiniGrid-Dynamic-Obstacles-5x5-v0")
+        >>> _, _ = env.reset(seed=2)
+        >>> _, reward, term, *_ = env.step(2)
+        >>> reward, term
+        (-1, True)
+        >>>
+        >>> env = NoDeath(env, ["ball"], -1)
+        >>> _, _ = env.reset(seed=2)
+        >>> _, reward, term, *_ = env.step(2)
+        >>> reward, term
+        (-2, False)
+    """
+
+    def __init__(self, env, no_death_types: tuple[str, ...], death_cost: float = -1.):
+        """A wrapper to prevent death in specific cells.
+
+        Args:
+            env: The environment to apply the wrapper
+            no_death_types: List of strings to identify death cells
+            death_cost: The negative reward received in death cells
+
+        """
+        assert "goal" not in no_death_types, "goal cannot be a death cell"
+
+        super().__init__(env)
+        self.death_cost = death_cost
+        self.no_death_types = no_death_types
+
+    def step(self, action):
+        # In Dynamic-Obstacles, obstacles move after the agent moves,
+        # so we need to check for collision before self.env.step()
+        front_cell = self.grid.get(*self.front_pos)
+        going_to_death = (
+            action == self.actions.forward and
+            front_cell is not None and
+            front_cell.type in self.no_death_types
+        )
+
+        obs, reward, terminated, truncated, info = self.env.step(action)
+
+        # We also check if the agent stays in death cells (e.g., lava)
+        # without moving
+        current_cell = self.grid.get(*self.agent_pos)
+        in_death = (
+            current_cell is not None and
+            current_cell.type in self.no_death_types
+        )
+
+        if terminated and (going_to_death or in_death):
+            terminated = False
+            reward += self.death_cost
+
+        return obs, reward, terminated, truncated, info

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -806,7 +806,7 @@ class NoDeath(Wrapper):
         >>> reward, term
         (0, True)
         >>>
-        >>> env = NoDeath(env, ["lava"], -1)
+        >>> env = NoDeath(env, no_death_types=("lava",), death_cost=-1.0)
         >>> _, _ = env.reset(seed=2)
         >>> _, _, _, _, _ = env.step(1)
         >>> _, reward, term, *_ = env.step(2)
@@ -820,14 +820,14 @@ class NoDeath(Wrapper):
         >>> reward, term
         (-1, True)
         >>>
-        >>> env = NoDeath(env, ["ball"], -1)
+        >>> env = NoDeath(env, no_death_types=("ball",), death_cost=-1.0)
         >>> _, _ = env.reset(seed=2)
         >>> _, reward, term, *_ = env.step(2)
         >>> reward, term
         (-2, False)
     """
 
-    def __init__(self, env, no_death_types: tuple[str, ...], death_cost: float = -1.):
+    def __init__(self, env, no_death_types: tuple[str, ...], death_cost: float = -1.0):
         """A wrapper to prevent death in specific cells.
 
         Args:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -24,6 +24,7 @@ from minigrid.wrappers import (
     StochasticActionWrapper,
     SymbolicObsWrapper,
     ViewSizeWrapper,
+    NoDeath,
 )
 from tests.utils import all_testing_env_specs, assert_equals, minigrid_testing_env_specs
 
@@ -356,3 +357,35 @@ def test_dict_observation_space_doesnt_clash_with_one_hot():
     assert obs["image"].shape == (7, 7, 20)
     assert env.observation_space["image"].shape == (7, 7, 20)
     env.close()
+
+
+def test_no_death_wrapper():
+    death_cost = -1
+
+    env = gym.make("MiniGrid-LavaCrossingS9N1-v0")
+    _, _ = env.reset(seed=2)
+    _, _, _, _, _ = env.step(1)
+    _, reward, term, *_ = env.step(2)
+
+    env_wrap = NoDeath(env, ["lava"], death_cost)
+    _, _ = env_wrap.reset(seed=2)
+    _, _, _, _, _ = env_wrap.step(1)
+    _, reward_wrap, term_wrap, *_ = env_wrap.step(2)
+
+    assert term and not term_wrap
+    assert reward_wrap == reward + death_cost
+    env.close()
+    env_wrap.close()
+
+    env = gym.make("MiniGrid-Dynamic-Obstacles-5x5-v0")
+    _, _ = env.reset(seed=2)
+    _, reward, term, *_ = env.step(2)
+
+    env = NoDeath(env, ["ball"], death_cost)
+    _, _ = env.reset(seed=2)
+    _, reward_wrap, term_wrap, *_ = env.step(2)
+
+    assert term and not term_wrap
+    assert reward_wrap == reward + death_cost
+    env.close()
+    env_wrap.close()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -16,6 +16,7 @@ from minigrid.wrappers import (
     FlatObsWrapper,
     FullyObsWrapper,
     ImgObsWrapper,
+    NoDeath,
     OneHotPartialObsWrapper,
     PositionBonus,
     ReseedWrapper,
@@ -24,7 +25,6 @@ from minigrid.wrappers import (
     StochasticActionWrapper,
     SymbolicObsWrapper,
     ViewSizeWrapper,
-    NoDeath,
 )
 from tests.utils import all_testing_env_specs, assert_equals, minigrid_testing_env_specs
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -367,7 +367,7 @@ def test_no_death_wrapper():
     _, _, _, _, _ = env.step(1)
     _, reward, term, *_ = env.step(2)
 
-    env_wrap = NoDeath(env, ["lava"], death_cost)
+    env_wrap = NoDeath(env, ("lava",), death_cost)
     _, _ = env_wrap.reset(seed=2)
     _, _, _, _, _ = env_wrap.step(1)
     _, reward_wrap, term_wrap, *_ = env_wrap.step(2)
@@ -381,7 +381,7 @@ def test_no_death_wrapper():
     _, _ = env.reset(seed=2)
     _, reward, term, *_ = env.step(2)
 
-    env = NoDeath(env, ["ball"], death_cost)
+    env = NoDeath(env, ("ball",), death_cost)
     _, _ = env.reset(seed=2)
     _, reward_wrap, term_wrap, *_ = env.step(2)
 


### PR DESCRIPTION
New wrapper that prevents death in states like obstacles or lava, and gives an optional negative reward instead.

# Description

The wrapper makes it possible to investigate exploration and safety. 
Making it possible to walk on lava (at a cost) would make exploration more interesting because the agent can find some "aggressive" exploration strategies, like walking over lava to explore as much as possible. This would be a scenario that should be avoided in safe RL.

More discussion here
https://github.com/Farama-Foundation/Minigrid/issues/372

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

