### PR TITLE
Dynamically determine `highlighting` in `RGBImgObsWrapper`

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -314,7 +314,11 @@ class RGBImgObsWrapper(ObservationWrapper):
         new_image_space = spaces.Box(
             low=0,
             high=255,
-            shape=(self.env.width * tile_size, self.env.height * tile_size, 3),
+            shape=(
+                self.unwrapped.width * tile_size,
+                self.unwrapped.height * tile_size,
+                3,
+            ),
             dtype="uint8",
         )
 
@@ -323,7 +327,9 @@ class RGBImgObsWrapper(ObservationWrapper):
         )
 
     def observation(self, obs):
-        rgb_img = self.get_frame(highlight=self.env.highlight, tile_size=self.tile_size)
+        rgb_img = self.get_frame(
+            highlight=self.unwrapped.highlight, tile_size=self.tile_size
+        )
 
         return {**obs, "image": rgb_img}
 

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -323,7 +323,7 @@ class RGBImgObsWrapper(ObservationWrapper):
         )
 
     def observation(self, obs):
-        rgb_img = self.get_frame(highlight=True, tile_size=self.tile_size)
+        rgb_img = self.get_frame(highlight=self.env.highlight, tile_size=self.tile_size)
 
         return {**obs, "image": rgb_img}
 


### PR DESCRIPTION
# Description

Changes the `observation` method of `RGBImgObsWrapper` such that the agent field-of-view (FOV) highlight is rendered only when the underlying environment has this enabled with the `highlight` bool. (default True). Previously the FOV highlighting was hardcoded to always be enabled, regardless of what `highlight` was.

Fixes #382, #326

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
