### PR TITLE
Change registry params of `BabyAI-GoToObjS6-v0`

### DIFF
--- a/minigrid/__init__.py
+++ b/minigrid/__init__.py
@@ -595,9 +595,9 @@ def register_minigrid_envs():
     )
 
     register(
-        id="BabyAI-GoToObjS6-v0",
+        id="BabyAI-GoToObjS6-v1",
         entry_point="minigrid.envs.babyai:GoToObj",
-        kwargs={"room_size": 4},
+        kwargs={"room_size": 6},
     )
 
     register(

--- a/minigrid/envs/babyai/goto.py
+++ b/minigrid/envs/babyai/goto.py
@@ -243,7 +243,9 @@ class GoToObj(RoomGridLevel):
 
     - `BabyAI-GoToObj-v0`
     - `BabyAI-GoToObjS4-v0`
-    - `BabyAI-GoToObjS6-v0`
+    - `BabyAI-GoToObjS6-v1`
+
+    Notice: `BabyAI-GoToObjS6-v0` is no longer for use due to a bug in the registry parameters.
 
     """
 


### PR DESCRIPTION
# Description

I found the registry param `room_size` of Env `BabyAI-GoToObjS6-v0` is wrong and simply fix it. I do a quick glance at other env registries and do not find other similar mistakes. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
