### PR TITLE
Update publications.md

### DIFF
--- a/docs/content/publications.md
+++ b/docs/content/publications.md
@@ -10,6 +10,7 @@ List of publications & submissions using Minigrid or BabyAI (please open a pull 
 - [Hierarchies of Reward Machines](https://arxiv.org/abs/2205.15752) (Imperial College London, ILASP, Universitat Pompeu Fabra, ICML 2023)
 - [Minimal Value-Equivalent Partial Models for Scalable and Robust Planning in Lifelong Reinforcement Learning](https://arxiv.org/abs/2301.10119) (Mila, McGill University, CoLLAs 2023)
 - [DEIR: Efficient and Robust Exploration through Discriminative-Model-Based Episodic Intrinsic Rewards](https://arxiv.org/abs/2304.10770) (U-Tokyo, Google Brain, IJCAI 2023)
+- [Contrastive Meta-Learning for Partially Observable Few-Shot Learning](https://arxiv.org/abs/2301.13136) (University of Edinburgh, Microsoft Research Cambridge, ICLR 2023)
 - [Towards Improving Exploration in Self-Imitation Learning using Intrinsic Motivation](https://arxiv.org/abs/2211.16838) (TECNALIA, IEEE ADPRL 2022)
 - [An Evaluation Study of Intrinsic Motivation Techniques applied to Reinforcement Learning over Hard Exploration Environments](https://arxiv.org/abs/2205.11184) (TECNALIA, CD-MAKE 2022)
 - [Evolution Strategies for Sparse Reward Gridworld Environments.](https://link.springer.com/chapter/10.1007/978-3-031-22695-3_19) (DSTG, AJCAI 2022)


### PR DESCRIPTION
Add "Contrastive Meta-Learning for Partially Observable Few-Shot Learning" (published at ICLR 2023) to list of publications.

Paper uses Minigrid to investigate learning an environment representation (map) from partial agent observations.

Thank you for the great environment!
