### PR TITLE
Fix typo in door key env description

### DIFF
--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -12,7 +12,7 @@ class DoorKeyEnv(MiniGridEnv):
     ## Description
 
     This environment has a key that the agent must pick up in order to unlock a
-    goal and then get to the green goal square. This environment is difficult,
+    door and then get to the green goal square. This environment is difficult,
     because of the sparse reward, to solve using classical RL algorithms. It is
     useful to experiment with curiosity or curriculum learning.
 


### PR DESCRIPTION
# Description

This corrects just one typo on the door key env description.
