### PR TITLE
Update create_env_tutorial.md

### DIFF
--- a/docs/content/create_env_tutorial.md
+++ b/docs/content/create_env_tutorial.md
@@ -37,7 +37,7 @@ class SimpleEnv(MiniGridEnv):
         return "grand mission"
 ```
 
-First, we need to create a class the inherits from `MiniGridEnv`, we call our class `SimpleEnv`. Then, we define a mission space, the recommended way to do it is to define a static function
+First, we need to create a class that inherits from `MiniGridEnv`, we call our class `SimpleEnv`. Then, we define a mission space, the recommended way to do it is to define a static function.
 
 ```python
 @staticmethod


### PR DESCRIPTION
Typo: the => that

# Description

There was a typo in the description using the instead of that in the sentence, also "." at end of sentence.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.






# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
