### PR TITLE
Bug Fix for the RGBImgPartialObsWrapper view size issue

### DIFF
--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -649,16 +649,19 @@ class MiniGridEnv(gym.Env):
 
         return obs
 
-    def get_pov_render(self, tile_size):
+    def get_pov_render(self, tile_size, agent_view_size=None):
         """
         Render an agent's POV observation for visualization
+        if agent_view_size is None, self.agent_view_size is used
         """
-        grid, vis_mask = self.gen_obs_grid()
+        agent_view_size = agent_view_size or self.agent_view_size
+
+        grid, vis_mask = self.gen_obs_grid(agent_view_size)
 
         # Render the whole grid
         img = grid.render(
             tile_size,
-            agent_pos=(self.agent_view_size // 2, self.agent_view_size - 1),
+            agent_pos=(agent_view_size // 2, agent_view_size - 1),
             agent_dir=3,
             highlight_mask=vis_mask,
         )

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -335,11 +335,13 @@ class RGBImgPartialObsWrapper(ObservationWrapper):
     """
     Wrapper to use partially observable RGB image as observation.
     This can be used to have the agent to solve the gridworld in pixel space.
+    Use ``ViewSizeWrapper`` to set the partial observation size, which
+    defaults to 7 tiles, i.e. (56, 56, 3) pixels at the default tile size.
 
     Example:
         >>> import gymnasium as gym
         >>> import matplotlib.pyplot as plt
-        >>> from minigrid.wrappers import RGBImgObsWrapper, RGBImgPartialObsWrapper
+        >>> from minigrid.wrappers import RGBImgObsWrapper, RGBImgPartialObsWrapper, ViewSizeWrapper
         >>> env = gym.make("MiniGrid-LavaCrossingS11N5-v0")
         >>> obs, _ = env.reset()
         >>> plt.imshow(obs["image"])  # doctest: +SKIP
@@ -352,6 +354,10 @@ class RGBImgPartialObsWrapper(ObservationWrapper):
         >>> obs, _ = env_obs.reset()
         >>> plt.imshow(obs["image"])  # doctest: +SKIP
         ![RGBImgPartialObsWrapper](../figures/lavacrossing_RGBImgPartialObsWrapper.png)
+        >>> env_obs = RGBImgPartialObsWrapper(ViewSizeWrapper(env, agent_view_size=5))
+        >>> obs, _ = env_obs.reset()
+        >>> obs["image"].shape
+        (40, 40, 3)
     """
 
     def __init__(self, env, tile_size=8):
@@ -361,6 +367,14 @@ class RGBImgPartialObsWrapper(ObservationWrapper):
         self.tile_size = tile_size
 
         obs_shape = env.observation_space.spaces["image"].shape
+
+        # The wrapped env may narrow the agent's view (e.g. ViewSizeWrapper), in
+        # which case unwrapped.agent_view_size is stale. Deriving the view size
+        # from the observation space being wrapped keeps the rendered image and
+        # observation_space consistent.
+        # See https://github.com/Farama-Foundation/Minigrid/issues/419
+        self.agent_view_size = obs_shape[0]
+
         new_image_space = spaces.Box(
             low=0,
             high=255,
@@ -373,8 +387,8 @@ class RGBImgPartialObsWrapper(ObservationWrapper):
         )
 
     def observation(self, obs):
-        rgb_img_partial = self.unwrapped.get_frame(
-            tile_size=self.tile_size, agent_pov=True
+        rgb_img_partial = self.unwrapped.get_pov_render(
+            tile_size=self.tile_size, agent_view_size=self.agent_view_size
         )
 
         return {**obs, "image": rgb_img_partial}

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -9,6 +9,7 @@ import pytest
 
 from minigrid.core.actions import Actions
 from minigrid.core.constants import OBJECT_TO_IDX
+from minigrid.core.grid import Grid
 from minigrid.envs import EmptyEnv
 from minigrid.wrappers import (
     ActionBonus,
@@ -401,3 +402,67 @@ def test_non_square_RGBIMgObsWrapper():
     env = RGBImgObsWrapper(gym.make("MiniGrid-BlockedUnlockPickup-v0"))
     obs, info = env.reset()
     assert env.observation_space["image"].shape == obs["image"].shape
+
+
+@pytest.mark.parametrize("view_size", [3, 5, 7, 9])
+def test_rgb_img_partial_obs_wrapper_view_size(view_size):
+    """
+    RGBImgPartialObsWrapper must honour the view size of the env it wraps
+    (https://github.com/Farama-Foundation/Minigrid/issues/419).
+    """
+    env = RGBImgPartialObsWrapper(
+        ViewSizeWrapper(gym.make("MiniGrid-DoorKey-8x8-v0"), agent_view_size=view_size)
+    )
+    side = view_size * env.tile_size
+
+    obs, _ = env.reset(seed=10)
+    assert env.observation_space["image"].shape == (side, side, 3)
+    assert obs["image"].shape == (side, side, 3)
+    assert env.observation_space["image"].contains(obs["image"])
+
+    obs, _, _, _, _ = env.step(0)
+    assert obs["image"].shape == (side, side, 3)
+    assert env.observation_space["image"].contains(obs["image"])
+    env.close()
+
+
+@pytest.mark.parametrize("view_size", [3, 5, 7])
+def test_rgb_img_partial_obs_wrapper_matches_symbolic_obs(view_size):
+    """
+    The rendered image must depict exactly the cells reported by the symbolic
+    observation of the wrapped env, and no others.
+    """
+    env_id = "MiniGrid-DoorKey-8x8-v0"
+    sym_env = ViewSizeWrapper(gym.make(env_id), agent_view_size=view_size)
+    rgb_env = RGBImgPartialObsWrapper(
+        ViewSizeWrapper(gym.make(env_id), agent_view_size=view_size)
+    )
+
+    sym_obs, _ = sym_env.reset(seed=10)
+    rgb_obs, _ = rgb_env.reset(seed=10)
+
+    grid, vis_mask = Grid.decode(sym_obs["image"])
+    expected = grid.render(
+        rgb_env.tile_size,
+        agent_pos=(grid.width // 2, grid.height - 1),
+        agent_dir=3,
+        highlight_mask=vis_mask,
+    )
+
+    assert np.array_equal(rgb_obs["image"], expected)
+    sym_env.close()
+    rgb_env.close()
+
+
+def test_rgb_img_partial_obs_wrapper_default_view_size_unchanged():
+    """
+    Without ViewSizeWrapper the observation must stay identical to the agent
+    POV frame rendered by the underlying environment.
+    """
+    env = RGBImgPartialObsWrapper(gym.make("MiniGrid-LavaCrossingS11N5-v0"))
+    obs, _ = env.reset(seed=10)
+
+    expected = env.unwrapped.get_frame(tile_size=env.tile_size, agent_pov=True)
+    assert np.array_equal(obs["image"], expected)
+    assert env.observation_space["image"].shape == obs["image"].shape
+    env.close()


### PR DESCRIPTION
## Description

Fixes issue #419 (and partly #468): `RGBImgPartialObsWrapper` rendered its image via `self.unwrapped`, which skips every wrapper, so it always used the base env's `agent_view_size`. Wrapping a `ViewSizeWrapper` therefore returned the default view regardless, and the observation no longer matched its own `observation_space`.

## Changes

- `minigrid_env.py` — `get_pov_render` takes an optional `agent_view_size`, matching `gen_obs_grid` and `get_view_exts`. It defaults to `self.agent_view_size`, so existing behaviour is unchanged.
- `wrappers.py` — the wrapper derives the view size from the observation space it wraps, so the image and `observation_space` cannot disagree. Docstring updated with an example.
- `tests/test_wrappers.py` — new tests.

## Tests

Cover a range of view sizes, check the rendered image against the symbolic observation rather than only its shape, and guard that the default view is unchanged. Several fail on `main` today and the fix resolves it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### Screenshots
Please attach before and after screenshots of the change if applicable.
![output_before](https://github.com/Farama-Foundation/Minigrid/assets/18087071/0e504f87-80be-47e0-adce-796dd8abad91)
![output_after](https://github.com/Farama-Foundation/Minigrid/assets/18087071/e5a538ed-07f0-4823-be36-47c917c1b31b)
<!--To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->
<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

