### PR TITLE
Fix issue when generating non-square DoorKey environments

### DIFF
--- a/minigrid/envs/doorkey.py
+++ b/minigrid/envs/doorkey.py
@@ -91,7 +91,7 @@ class DoorKeyEnv(MiniGridEnv):
         self.place_agent(size=(splitIdx, height))
 
         # Place a door in the wall
-        doorIdx = self._rand_int(1, width - 2)
+        doorIdx = self._rand_int(1, height - 2)
         self.put_obj(Door("yellow", is_locked=True), splitIdx, doorIdx)
 
         # Place a yellow key on the left side


### PR DESCRIPTION
# Description

Fix issue as explained in
https://github.com/Farama-Foundation/Minigrid/issues/427#issuecomment-2051995146

## Type of change
- [x]  Bug fix (non-breaking change which fixes an issue)

### Screenshots

Code illustrating the issue:

    from minigrid.envs.doorkey import DoorKeyEnv
    env = DoorKeyEnv(render_mode='human', size=6)
    env.reset(seed=1)
    env._gen_grid(6,4)
    env.render()

| Before | After |
| ------ | ----- |
|![2024-04-22-150154_640x640_scrot](https://github.com/Farama-Foundation/Minigrid/assets/17003168/ace41f4f-6750-48e0-9672-ced7ad42dddf) |![2024-04-22-150334_640x640_scrot](https://github.com/Farama-Foundation/Minigrid/assets/17003168/7ee44231-da7a-4cfe-a2ec-17bcdb274bb5)
<!--
Example:

| Before | After |
| ------ | ----- |
|![2024-04-22-150154_640x640_scrot](https://github.com/Farama-Foundation/Minigrid/assets/17003168/ace41f4f-6750-48e0-9672-ced7ad42dddf) |![2024-04-22-150334_640x640_scrot](https://github.com/Farama-Foundation/Minigrid/assets/17003168/7ee44231-da7a-4cfe-a2ec-17bcdb274bb5)
|


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# My testing procedure

    python -m venv .env
    . .env/bin/activate
    pip install -r requirements.txt -r test_requirements.txt
    python -m pip install -e .
    pytest

Pytest output:

```
============================= test session starts ==============================
platform linux -- Python 3.11.8, pytest-8.1.1, pluggy-1.5.0
rootdir: /home/raf/minigrid-bugfix/raf-fork-2
configfile: pyproject.toml
plugins: mock-3.14.0
collected 3113 items

tests/test_baby_ai_bot.py .............................................. [  1%]
..............................................                           [  2%]
tests/test_envs.py ..................................................... [  4%]
........................................................................ [  6%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 30%]
.................                                                        [ 30%]
tests/test_obstructed_maze.py ....                                       [ 30%]
tests/test_scripts.py ..                                                 [ 30%]
tests/test_wfc/test_wfc_adjacency.py .                                   [ 30%]
tests/test_wfc/test_wfc_patterns.py ...                                  [ 30%]
tests/test_wfc/test_wfc_solver.py .....                                  [ 31%]
tests/test_wfc/test_wfc_tiles.py ..                                      [ 31%]
tests/test_wrappers.py ................................................. [ 32%]
........................................................................ [ 35%]
........................................................................ [ 37%]
........................................................................ [ 39%]
........................................................................ [ 42%]
........................................................................ [ 44%]
........................................................................ [ 46%]
........................................................................ [ 48%]
........................................................................ [ 51%]
........................................................................ [ 53%]
........................................................................ [ 55%]
........................................................................ [ 58%]
.........s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 60%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 62%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 65%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 67%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 69%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 72%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 74%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 76%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 79%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.... [ 81%]
.s.s.....s.s.....s.s.....s.s.....s.s.....s.s.....s.s.................... [ 83%]
........................................................................ [ 85%]
........................................................................ [ 88%]
........................................................................ [ 90%]
........................................................................ [ 92%]
........................................................................ [ 95%]
........................................................................ [ 97%]
........................................................................ [ 99%]
.....                                                                    [100%]

=============================== warnings summary ===============================
tests/test_baby_ai_bot.py: 15 warnings
tests/test_obstructed_maze.py: 4 warnings
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.room_from_pos to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.room_from_pos` for environment variables or `env.get_wrapper_attr('room_from_pos')` that will search the reminding wrappers.
    logger.warn(

tests/test_baby_ai_bot.py: 15 warnings
tests/test_wrappers.py: 4 warnings
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.agent_pos to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.agent_pos` for environment variables or `env.get_wrapper_attr('agent_pos')` that will search the reminding wrappers.
    logger.warn(

tests/test_baby_ai_bot.py: 15 warnings
tests/test_envs.py: 1 warning
tests/test_obstructed_maze.py: 4 warnings
tests/test_wrappers.py: 4 warnings
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.grid to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.grid` for environment variables or `env.get_wrapper_attr('grid')` that will search the reminding wrappers.
    logger.warn(

tests/test_envs.py::test_agent_sees_method[MiniGrid-DoorKey-6x6-v0]
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.agent_sees to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.agent_sees` for environment variables or `env.get_wrapper_attr('agent_sees')` that will search the reminding wrappers.
    logger.warn(

tests/test_scripts.py: 1 warning
tests/test_wrappers.py: 344 warnings
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.get_frame to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.get_frame` for environment variables or `env.get_wrapper_attr('get_frame')` that will search the reminding wrappers.
    logger.warn(

tests/test_scripts.py::test_manual_control
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.step_count to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.step_count` for environment variables or `env.get_wrapper_attr('step_count')` that will search the reminding wrappers.
    logger.warn(

tests/test_wrappers.py: 75 warnings
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.mission to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.mission` for environment variables or `env.get_wrapper_attr('mission')` that will search the reminding wrappers.
    logger.warn(

tests/test_wrappers.py: 346 warnings
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.width to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.width` for environment variables or `env.get_wrapper_attr('width')` that will search the reminding wrappers.
    logger.warn(

tests/test_wrappers.py: 346 warnings
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.height to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.height` for environment variables or `env.get_wrapper_attr('height')` that will search the reminding wrappers.
    logger.warn(

tests/test_wrappers.py::test_symbolic_obs_wrapper[MiniGrid-DistShift1-v0]
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.goal_pos to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.goal_pos` for environment variables or `env.get_wrapper_attr('goal_pos')` that will search the reminding wrappers.
    logger.warn(

tests/test_wrappers.py::test_symbolic_obs_wrapper[MiniGrid-DistShift1-v0]
tests/test_wrappers.py::test_symbolic_obs_wrapper[MiniGrid-DistShift1-v0]
tests/test_wrappers.py::test_symbolic_obs_wrapper[MiniGrid-DistShift1-v0]
tests/test_wrappers.py::test_symbolic_obs_wrapper[MiniGrid-DistShift1-v0]
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/_pytest/python.py:195: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    result = testfunction(**testargs)

tests/test_wrappers.py::test_no_death_wrapper
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.front_pos to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.front_pos` for environment variables or `env.get_wrapper_attr('front_pos')` that will search the reminding wrappers.
    logger.warn(

tests/test_wrappers.py::test_no_death_wrapper
  /home/raf/minigrid-bugfix/raf-fork-2/.env/lib/python3.11/site-packages/gymnasium/core.py:311: UserWarning: WARN: env.actions to get variables from other wrappers is deprecated and will be removed in v1.0, to get this variable you can do `env.unwrapped.actions` for environment variables or `env.get_wrapper_attr('actions')` that will search the reminding wrappers.
    logger.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========= 2921 passed, 192 skipped, 1183 warnings in 150.22s (0:02:30) =========
```


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
