### PR TITLE
doc fix env-id param

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -13,10 +13,10 @@ There is a UI application which allows you to manually control the agent with th
 ./minigrid/manual_control.py
 ```
 
-The environment being run can be selected with the `--env` option, eg:
+The environment being run can be selected with the `--env-id` option, eg:
 
 ```bash
-./minigrid/manual_control.py --env MiniGrid-Empty-8x8-v0
+./minigrid/manual_control.py --env-id MiniGrid-Empty-8x8-v0
 ```
 
 ## Installation


### PR DESCRIPTION
# Description

Accordint to the [source code](https://github.com/Farama-Foundation/Minigrid/blob/a7a6725aabd3d2a4e9edf6b11739208efe1d5520/minigrid/manual_control.py#L88), its `--env-id` and not `--env`

https://github.com/Farama-Foundation/Minigrid/blob/a7a6725aabd3d2a4e9edf6b11739208efe1d5520/minigrid/manual_control.py#L87-L89

## Type of change

Please delete options that are not relevant.

- [x] Documentation fix