### PR TITLE
Swap width and height in RGBImgObsWrapper, add test

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -313,8 +313,8 @@ class RGBImgObsWrapper(ObservationWrapper):
             low=0,
             high=255,
             shape=(
-                self.unwrapped.width * tile_size,
                 self.unwrapped.height * tile_size,
+                self.unwrapped.width * tile_size,
                 3,
             ),
             dtype="uint8",

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -389,3 +389,13 @@ def test_no_death_wrapper():
     assert reward_wrap == reward + death_cost
     env.close()
     env_wrap.close()
+
+
+def test_non_square_RGBIMgObsWrapper():
+    """
+    Add test for non-square dimensions with RGBImgObsWrapper
+    (https://github.com/Farama-Foundation/Minigrid/issues/444).
+    """
+    env = RGBImgObsWrapper(gym.make("MiniGrid-BlockedUnlockPickup-v0"))
+    obs, info = env.reset()
+    assert env.observation_space["image"].shape == obs["image"].shape


### PR DESCRIPTION
# Description

This PR swaps the order of `width` and `height` for `RGBImgObsWrapper`, fixing a bug noted in #444. It also adds a test to verify the assertion statement from that issue.

Fixes #444

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

N/A

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
