### PR TITLE
Interacting with an empty box, deletes the box, creating an unsolvable situation in the BlockedUnlockPickupEnv.

### DIFF
--- a/minigrid/core/world_object.py
+++ b/minigrid/core/world_object.py
@@ -288,6 +288,10 @@ class Box(WorldObj):
         fill_coords(img, point_in_rect(0.16, 0.84, 0.47, 0.53), c)
 
     def toggle(self, env, pos):
+        # if the box is empty, do nothing
+        if self.contains is None:
+            return False
+
         # Replace the box by its contents
         env.grid.set(pos[0], pos[1], self.contains)
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.18.0
 gymnasium>=0.26
 pygame>=2.2.0
+opencv-python


### PR DESCRIPTION
# Description

This PR concerns a sequence of actions in the [BlockedUnlockPickupEnv](https://minigrid.farama.org/environments/minigrid/BlockedUnlockPickupEnv/) environment that will make an unsolvable situation in this environment. This environment requires the player to first move the obstacle out of the way, unlock the door, and then pick up the box. If instead, the agent interacts with the box and does not pick up the box, the box will be replaced with a None object and the box is subsequently deleted. In this environment, if the box is deleted by interacting with the box, the environment becomes unsolvable.

If this environment becomes unsolvable, the level and will require a reset or timeout. This PR changes the toggle behaviour of boxes to do nothing if the box is empty, preventing an agent from accidentally deleting boxes and creating an unsolvable situation. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
  - I believe there are no relevant docs to update.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
  - I don't believe expected functionality of boxes have tests, this is outside the scope of this PR though.
- [x] New and existing unit tests pass locally with my changes
  - Same as last comment