### PR TITLE
Allow custom goal colours

### DIFF
--- a/minigrid/core/world_object.py
+++ b/minigrid/core/world_object.py
@@ -107,8 +107,8 @@ class WorldObj:
 
 
 class Goal(WorldObj):
-    def __init__(self):
-        super().__init__("goal", "green")
+    def __init__(self, color: str = "green"):
+        super().__init__("goal", color)
 
     def can_overlap(self):
         return True


### PR DESCRIPTION
# Description

Hi,

I've often found it useful to be able to customise the goal colour when building custom environments for example, when making an environment that can have multiple goals etc.

I'm pretty confident this doesn't break or change anything (as I have just made the default "green" as it always is), but do let me know if any concerns -- thanks!

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

