### PR TITLE
[Docs] Fix incorrect links to Python modules in docs

### DIFF
--- a/docs/_modules/minigrid/core/constants.md
+++ b/docs/_modules/minigrid/core/constants.md
@@ -1,0 +1,10 @@
+---
+title: Source code for minigrid.core.constants
+orphan: true
+---
+
+# Source code for minigrid.core.constants
+
+```{literalinclude} ../../../../minigrid/core/constants.py
+:language: python
+```

--- a/docs/_scripts/gen_env_docs.py
+++ b/docs/_scripts/gen_env_docs.py
@@ -67,12 +67,30 @@ filtered_babyai_envs = {
 canonical_wfc_env_name = "MazeSimple"
 filtered_wfc_envs = {canonical_wfc_env_name: wfc_envs[canonical_wfc_env_name]}
 
+SOURCE_PY_LINK_PATTERN = re.compile(r"\((/)?(minigrid/[A-Za-z0-9_./-]+)\.py\)")
+
+
+def _rewrite_doc_links(docstring: str) -> str:
+    """Rewrite source-style links into docs-relative links for generated pages.
+
+    Any markdown link target of the form `(minigrid/***.py)` becomes:
+    `(./../../_modules/minigrid/***/)`
+    """
+
+    def _to_modules_link(match: re.Match) -> str:
+        module_path = match.group(2)
+        return f"(./../../_modules/{module_path}/)"
+
+    return SOURCE_PY_LINK_PATTERN.sub(_to_modules_link, docstring)
+
+
 for env_name, env_spec in chain(
     filtered_envs.items(), filtered_babyai_envs.items(), filtered_wfc_envs.items()
 ):
     env = env_spec.make()
 
     docstring = trim(env.unwrapped.__doc__)
+    docstring = _rewrite_doc_links(docstring)
 
     # minigrid.envs:Env or minigrid.envs.babyai:Env
     split = env_spec.entry_point.split(".")

--- a/docs/api/wrapper.md
+++ b/docs/api/wrapper.md
@@ -1,6 +1,8 @@
 ---
 title: Wrapper
 lastpage:
+myst:
+  all_links_external: true
 ---
 
 ## Wrapper
@@ -14,7 +16,7 @@ field which can be used as an optional compass. Using dictionaries makes it
 easy for you to add additional information to observations
 if you need to, without having to encode everything into a single tensor.
 
-There are a variety of wrappers to change the observation format available in [minigrid/wrappers.py](/minigrid/wrappers.py).
+There are a variety of wrappers to change the observation format available in [minigrid/wrappers.py](./../../_modules/minigrid/wrappers/).
 If your RL code expects one single tensor for observations, take a look at `FlatObsWrapper`.
 There is also an `ImgObsWrapper` that gets rid of the 'mission' field in observations, leaving only the image field tensor.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,3 +93,23 @@ html_css_files = []
 # -- Generate Changelog -------------------------------------------------
 
 sphinx_github_changelog_token = os.environ.get("SPHINX_GITHUB_CHANGELOG_TOKEN")
+
+
+# `viewcode` skips data-only modules in the module index, so add constants manually.
+def _add_constants_to_modules_index(app, pagename, templatename, context, doctree):
+    """Inject `minigrid.core.constants` into the viewcode modules index."""
+    if pagename != "_modules/index":
+        return
+
+    body = context.get("body", "")
+    if "minigrid/core/constants/" in body:
+        return
+
+    entry = '<li><a href="minigrid/core/constants/">minigrid.core.constants</a></li>'
+    marker = "</ul>"
+    if marker in body:
+        context["body"] = body.replace(marker, f"{entry}\n{marker}", 1)
+
+
+def setup(app):
+    app.connect("html-page-context", _add_constants_to_modules_index)


### PR DESCRIPTION
# Description

This PR fixes https://github.com/Farama-Foundation/Minigrid/issues/431

## Type of change

- [x] Documentation improvement

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] (N/A) I have added tests that prove my fix is effective or that my feature works
- [ ] (N/A) New and existing unit tests pass locally with my changes
