### PR TITLE
Fix MiniGrid-MultiRoom-N4-S5 (issue #471)

### DIFF
--- a/minigrid/__init__.py
+++ b/minigrid/__init__.py
@@ -368,7 +368,14 @@ def register_minigrid_envs():
     register(
         id="MiniGrid-MultiRoom-N4-S5-v0",
         entry_point="minigrid.envs:MultiRoomEnv",
+        # NOTE: kept for backwards compatibility; this legacy ID is configured for 6 rooms.
         kwargs={"minNumRooms": 6, "maxNumRooms": 6, "maxRoomSize": 5},
+    )
+
+    register(
+        id="MiniGrid-MultiRoom-N4-S5-v1",
+        entry_point="minigrid.envs:MultiRoomEnv",
+        kwargs={"minNumRooms": 4, "maxNumRooms": 4, "maxRoomSize": 5},
     )
 
     register(

--- a/minigrid/envs/multiroom.py
+++ b/minigrid/envs/multiroom.py
@@ -63,7 +63,8 @@ class MultiRoomEnv(MiniGridEnv):
     ## Registered Configurations
 
     - `MiniGrid-MultiRoom-N2-S4-v0` (two small rooms)
-    - `MiniGrid-MultiRoom-N4-S5-v0` (four rooms)
+    - `MiniGrid-MultiRoom-N4-S5-v0` (legacy, misconfigured for 6 rooms)
+    - `MiniGrid-MultiRoom-N4-S5-v1` (fixed, four rooms)
     - `MiniGrid-MultiRoom-N6-v0` (six rooms)
 
     ## Arguments


### PR DESCRIPTION
# Description

As described in #471, MiniGrid-MultiRoom-N4-S5-v0 is configured to produce 6 rooms and not 4 as the documentation suggests.

Fixes #471

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes