### PR TITLE
Fix gen_env_docs when canonical_wfc_env_name is not in wfc_envs

### DIFF
--- a/docs/_scripts/gen_env_docs.py
+++ b/docs/_scripts/gen_env_docs.py
@@ -65,7 +65,9 @@ filtered_babyai_envs = {
 
 # Because they share a class, only the default (MazeSimple) environment should be kept
 canonical_wfc_env_name = "MazeSimple"
-filtered_wfc_envs = {canonical_wfc_env_name: wfc_envs[canonical_wfc_env_name]}
+filtered_wfc_envs = {}
+for canonical_wfc_env_name in wfc_envs:
+    filtered_wfc_envs[canonical_wfc_env_name] = wfc_envs[canonical_wfc_env_name]
 
 for env_name, env_spec in chain(
     filtered_envs.items(), filtered_babyai_envs.items(), filtered_wfc_envs.items()


### PR DESCRIPTION
# Description

As in the title

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
