### PR TITLE
Fix doc site title casing and non-deterministic seeded reset in BabyAI LevelGen envs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ napoleon_custom_sections = [("Returns", "params_style")]
 # a list of builtin themes.
 #
 html_theme = "celshast"
-html_title = "MiniGrid Documentation"
+html_title = "Minigrid Documentation"
 html_baseurl = "https://minigrid.farama.org/"
 html_copy_source = False
 html_favicon = "_static/img/minigrid-favicon.png"

--- a/minigrid/envs/babyai/core/levelgen.py
+++ b/minigrid/envs/babyai/core/levelgen.py
@@ -57,6 +57,13 @@ class LevelGen(RoomGridLevel):
         )
 
     def gen_mission(self):
+        # `add_locked_room()` below only runs some of the time, so without this
+        # a mission would inherit the previous one's room. The room grid is
+        # rebuilt before every mission, making any retained room stale, and
+        # `rand_obj()` samples against it -- so the leak would let one episode
+        # change the objects picked by the next.
+        self.locked_room = None
+
         if self._rand_float(0, 1) < self.locked_room_prob:
             self.add_locked_room()
 


### PR DESCRIPTION
Two changes: the documentation title fix this PR started as, plus a fix for the CI failure it was hitting.

## Doc site title casing

The documentation site title and the browser-tab title/tooltip rendered as "MiniGrid Documentation", while the project name is "Minigrid" (as set in `project` in `conf.py`). This updates `html_title` so the site title and tab tooltip read "Minigrid Documentation".

Scoped intentionally to the title only — `MiniGrid-*` environment IDs and the `MiniGridEnv` class name are left unchanged since those are real registered identifiers.

## Non-deterministic seeded reset in BabyAI `LevelGen` envs

`tests/test_envs.py::test_env[BabyAI-Synth-v0]` was failing on this branch with:

```
AssertionError: Using `env.reset(seed=123)` is non-deterministic as the observations are not equivalent.
```

This is a pre-existing bug, not something this branch introduced — it reproduces on `main` and fails in roughly 4% of runs, which is why `main` is usually green.

**Cause.** `LevelGen.locked_room` is initialised in `__init__` and only ever reassigned inside `add_locked_room()`, which `gen_mission()` calls with probability `locked_room_prob`. On any episode that doesn't add a locked room, the attribute still holds the previous episode's `Room`.

That stale value is not inert. `rand_obj()` filters candidate positions against `self.locked_room` when `implicit_unlock` is `False` (Synth's configuration), so a stale room changes which object descriptors are accepted and how much of the RNG stream is consumed. A seeded reset therefore depended on the episode that ran before it, not only on its seed.

**Why the env checker surfaces it.** `check_env` runs `check_reset_return_type` — an unseeded reset, so an entropy-seeded RNG — immediately before `check_reset_seed_determinism`. The first `reset(seed=123)` inherits a random locked room while the second inherits a deterministic one, so the two observations occasionally differ.

**Fix.** Clear `locked_room` at the start of `gen_mission()`. This is correct independently of the flake: `_gen_grid()` rebuilds the room grid before every attempt, so any retained `Room` is stale by then.

**Verification.** Over 100 seeded-reset trials per affected env (`Synth`, `SynthLoc`, `SynthSeq`, `MiniBossLevel`, `BossLevel`, `BossLevelNoUnlock`): 8/200 failures before, 0/600 after. Every other registered MiniGrid and BabyAI env was swept for the same leak — including the WFC envs with the `wfc` extra installed — and none were affected. Full suite locally: 3226 passed, 192 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
