### PR TITLE
Avoid full pygame.init() when rendering in human mode

### DIFF
--- a/minigrid/minigrid_env.py
+++ b/minigrid/minigrid_env.py
@@ -746,7 +746,13 @@ class MiniGridEnv(gym.Env):
             if self.render_size is None:
                 self.render_size = img.shape[:2]
             if self.window is None:
-                pygame.init()
+                # Rendering only needs the freetype subsystem (for the mission
+                # text) and the display, both initialized below. A full
+                # pygame.init() also starts the audio/joystick subsystems, which
+                # can take several seconds on some platforms (e.g. enumerating
+                # audio devices on Windows).
+                # See https://github.com/Farama-Foundation/Minigrid/issues/497
+                pygame.freetype.init()
                 pygame.display.init()
                 self.window = pygame.display.set_mode(
                     (self.screen_size, self.screen_size)


### PR DESCRIPTION
## Description

Closes #497.

When rendering in `human` mode, `MiniGridEnv.render()` calls `pygame.init()` immediately followed by `pygame.display.init()`. `pygame.init()` initializes **every** pygame subsystem — including audio and joystick — and enumerating audio devices can take several seconds on some platforms (notably Windows). Minigrid never uses sound or joystick input.

Human-mode rendering only needs:
- the **display** subsystem — already initialized right after via `pygame.display.init()`, and
- the **freetype** subsystem — used for the mission text (`pygame.freetype.SysFont`).

So this replaces the heavy `pygame.init()` with `pygame.freetype.init()`. `rgb_array` rendering returns the numpy image directly and touches no pygame subsystem at all.

This mirrors the same optimization requested across the Farama envs (see Farama-Foundation/PettingZoo#1252).

## Verification

Confirmed in isolation that after `pygame.freetype.init()` (without any `pygame.init()`), `pygame.freetype.SysFont(pygame.font.get_default_font(), ...)` renders text correctly while `pygame.mixer.get_init()` stays `None` and `pygame.display.get_init()` stays `False`. `black`, `isort`, `flake8` and `codespell` pass on the changed file.