### PR TITLE
Fix PositionBonus wrapper ignoring the `scale` parameter (issue #473)

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -157,10 +157,11 @@ class PositionBonus(Wrapper):
 
         Args:
             env: The environment to apply the wrapper
+            scale: The multiplier applied to the exploration bonus (default 1)
         """
         super().__init__(env)
         self.counts = {}
-        self.scale = 1
+        self.scale = scale
 
     def step(self, action):
         """Steps through the environment with `action`."""

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -112,6 +112,37 @@ def test_position_bonus_wrapper(env_id):
 
 
 @pytest.mark.parametrize("env_id", ["MiniGrid-Empty-16x16-v0"])
+@pytest.mark.parametrize("scale", [0.5, 2, 3.0])
+def test_position_bonus_wrapper_scale(env_id, scale):
+    env = gym.make(env_id)
+    wrapped_env = PositionBonus(gym.make(env_id), scale=scale)
+
+    action_forward = Actions.forward
+    action_left = Actions.left
+    action_right = Actions.right
+
+    for _ in range(10):
+        wrapped_env.reset()
+        for _ in range(5):
+            wrapped_env.step(action_forward)
+
+    # Turn left 3 times (check that actions don't influence bonus)
+    for _ in range(3):
+        _, wrapped_rew, _, _, _ = wrapped_env.step(action_left)
+
+    env.reset()
+    for _ in range(5):
+        env.step(action_forward)
+    # Turn right 3 times
+    for _ in range(3):
+        _, rew, _, _, _ = env.step(action_right)
+
+    expected_bonus_reward = rew + scale * (1 / math.sqrt(13))
+
+    assert expected_bonus_reward == wrapped_rew
+
+
+@pytest.mark.parametrize("env_id", ["MiniGrid-Empty-16x16-v0"])
 def test_action_bonus_wrapper(env_id):
     env = gym.make(env_id)
     wrapped_env = ActionBonus(gym.make(env_id))


### PR DESCRIPTION
## What

`PositionBonus.__init__` accepts a `scale` argument but hardcoded `self.scale = 1`, so the argument was silently discarded. `step()` computes `reward += bonus * self.scale`, meaning `PositionBonus(env, scale=k)` returned identical rewards for every `k`. This changes the assignment to use the passed-in `scale` and documents the parameter in the `Args:` docstring.

## Why

The `scale` parameter (added in #433) had no effect at all — the exploration bonus was always multiplied by 1 regardless of the value passed. See #473.

## Testing

Added `tests/test_wrappers.py::test_position_bonus_wrapper_scale`, a parametrized test over `scale` in `{0.5, 2, 3.0}` that checks the wrapped reward equals `base_reward + scale * bonus`. It fails on `main` (rewards are unchanged by `scale`) and passes with this fix.

```
pytest tests/test_wrappers.py -k position_bonus
....                                                                     [100%]
4 passed, 2155 deselected in 0.18s
```

Fixes #473
