### PR TITLE
Pass seed and options through DirectionObsWrapper.reset

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -697,7 +697,10 @@ class DirectionObsWrapper(ObservationWrapper):
     def reset(
         self, *, seed: int | None = None, options: dict[str, Any] | None = None
     ) -> tuple[ObsType, dict[str, Any]]:
-        obs, info = self.env.reset()
+        # `seed` and `options` used to be dropped here, which left the
+        # underlying environment unseeded: a seeded reset through this wrapper
+        # was not reproducible.
+        obs, info = self.env.reset(seed=seed, options=options)
 
         if not self.goal_position:
             self.goal_position = [

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -298,6 +298,32 @@ def test_direction_obs_wrapper(env_id, type):
     env.close()
 
 
+@pytest.mark.parametrize("env_id", ["MiniGrid-MultiRoom-N2-S4-v0"])
+def test_direction_obs_wrapper_seeding(env_id):
+    """A seeded reset through the wrapper must reproduce the layout.
+
+    The wrapper accepted ``seed`` and then called ``self.env.reset()`` without
+    it, so the underlying environment stayed unseeded and repeated resets with
+    the same seed gave different grids.
+    """
+    env = DirectionObsWrapper(gym.make(env_id), type="slope")
+
+    images = []
+    for _ in range(3):
+        obs, _ = env.reset(seed=42)
+        images.append(obs["image"].copy())
+    env.close()
+
+    for image in images[1:]:
+        assert np.array_equal(images[0], image)
+
+    # The same seed must also agree with the environment on its own.
+    plain_env = gym.make(env_id)
+    plain_obs, _ = plain_env.reset(seed=42)
+    plain_env.close()
+    assert np.array_equal(images[0], plain_obs["image"])
+
+
 @pytest.mark.parametrize("env_id", ["MiniGrid-DistShift1-v0"])
 def test_symbolic_obs_wrapper(env_id):
     env = gym.make(env_id)


### PR DESCRIPTION
## Summary

`DirectionObsWrapper.reset` accepts `seed` and `options` and then calls `self.env.reset()` without either, so the underlying environment is never seeded through the wrapper. A seeded reset is not reproducible:

```python
import gymnasium as gym
from minigrid.wrappers import DirectionObsWrapper

env = DirectionObsWrapper(gym.make("MiniGrid-MultiRoom-N2-S4-v0"), type="slope")
for _ in range(3):
    obs, _ = env.reset(seed=42)
    print(obs["image"].sum())
# 60
# 46
# 60
```

Measured on `MiniGrid-MultiRoom-N2-S4-v0`, three resets with the same seed:

| | `reset(seed=42)` three times |
|---|---|
| plain environment | `44, 44, 44` |
| `FullyObsWrapper` | `770, 770, 770` |
| `DirectionObsWrapper` | `60, 46, 60` |

The seed is ignored rather than mishandled: at `seed=1` the wrapper returns a layout that does not match the environment's own layout for that seed either.

Every other wrapper in `minigrid/wrappers.py` leaves `reset` to `gymnasium.Wrapper`, which forwards both arguments. This is the only place that overrides it, and it drops them.

## Changes

* `minigrid/wrappers.py` — forward `seed` and `options` to `self.env.reset()`, with a comment recording what the omission caused.
* `tests/test_wrappers.py` — a test asserting that three seeded resets agree with each other and with the unwrapped environment on the same seed.

## Verification

`tests/test_wrappers.py` was run before and after: **2043 passed, 192 skipped** with the change. With the fix reverted and the new test kept, exactly one test fails — the new one — and the other 2042 still pass, so nothing depended on the old behaviour and the test does detect the defect rather than passing regardless.

`black`, `isort --profile black`, `flake8` and `codespell` are clean on both files, using the arguments from `.pre-commit-config.yaml`.

## Noted separately

While checking this I also found that the wrapper adds `goal_direction` to the observation without declaring it in `observation_space`, so `observation_space.contains(obs)` is `False` for every observation it returns. Declaring it needs a decision first: on `MiniGrid-FourRooms-v0` the slope is `nan` when the agent stands on the goal's row and column, and no `Box` contains `nan`. That is left out of this PR — happy to open an issue for it, or a follow-up PR once you have a preference on what the value should be in that case.
