### PR TITLE
Declare the space SymbolicObsWrapper actually returns

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -726,6 +726,11 @@ class DirectionObsWrapper(ObservationWrapper):
         return obs
 
 
+# Pinned so the symbolic observation is the same on every platform. int64 is
+# what `np.mgrid` already produced on Linux and macOS, so only Windows changes.
+SYMBOLIC_OBS_DTYPE = np.int64
+
+
 class SymbolicObsWrapper(ObservationWrapper):
     """
     Fully observable grid with a symbolic state representation.
@@ -748,15 +753,24 @@ class SymbolicObsWrapper(ObservationWrapper):
     def __init__(self, env):
         super().__init__(env)
 
+        width, height = self.env.unwrapped.width, self.env.unwrapped.height
+
+        # One pair of bounds for all three channels was wrong at both ends. The
+        # first two channels hold the cell's coordinates, so they reach
+        # width - 1 and height - 1, which is above max(OBJECT_TO_IDX.values())
+        # on any grid larger than eleven cells; only the third holds an object
+        # index, and that is -1 where the cell is empty, which is below zero.
+        low = np.zeros((width, height, 3), dtype=SYMBOLIC_OBS_DTYPE)
+        low[:, :, 2] = -1
+        high = np.empty((width, height, 3), dtype=SYMBOLIC_OBS_DTYPE)
+        high[:, :, 0] = width - 1
+        high[:, :, 1] = height - 1
+        high[:, :, 2] = max(OBJECT_TO_IDX.values())
+
         new_image_space = spaces.Box(
-            low=0,
-            high=max(OBJECT_TO_IDX.values()),
-            shape=(
-                self.env.unwrapped.width,
-                self.env.unwrapped.height,
-                3,
-            ),  # number of cells
-            dtype="uint8",
+            low=low,
+            high=high,
+            dtype=SYMBOLIC_OBS_DTYPE,
         )
         self.observation_space = spaces.Dict(
             {**self.observation_space.spaces, "image": new_image_space}
@@ -777,7 +791,10 @@ class SymbolicObsWrapper(ObservationWrapper):
         grid = np.concatenate([grid, _objects])
         grid = np.transpose(grid, (1, 2, 0))
         grid[agent_pos[0], agent_pos[1], 2] = OBJECT_TO_IDX["agent"]
-        obs["image"] = grid
+        # `np.mgrid` follows the platform's default integer, so the observation
+        # was int32 on Windows and int64 elsewhere and no single declared dtype
+        # could match both.
+        obs["image"] = grid.astype(SYMBOLIC_OBS_DTYPE)
 
         return obs
 

--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -729,8 +729,6 @@ class DirectionObsWrapper(ObservationWrapper):
         return obs
 
 
-# Pinned so the symbolic observation is the same on every platform. int64 is
-# what `np.mgrid` already produced on Linux and macOS, so only Windows changes.
 SYMBOLIC_OBS_DTYPE = np.int64
 
 
@@ -758,11 +756,6 @@ class SymbolicObsWrapper(ObservationWrapper):
 
         width, height = self.env.unwrapped.width, self.env.unwrapped.height
 
-        # One pair of bounds for all three channels was wrong at both ends. The
-        # first two channels hold the cell's coordinates, so they reach
-        # width - 1 and height - 1, which is above max(OBJECT_TO_IDX.values())
-        # on any grid larger than eleven cells; only the third holds an object
-        # index, and that is -1 where the cell is empty, which is below zero.
         low = np.zeros((width, height, 3), dtype=SYMBOLIC_OBS_DTYPE)
         low[:, :, 2] = -1
         high = np.empty((width, height, 3), dtype=SYMBOLIC_OBS_DTYPE)
@@ -794,9 +787,6 @@ class SymbolicObsWrapper(ObservationWrapper):
         grid = np.concatenate([grid, _objects])
         grid = np.transpose(grid, (1, 2, 0))
         grid[agent_pos[0], agent_pos[1], 2] = OBJECT_TO_IDX["agent"]
-        # `np.mgrid` follows the platform's default integer, so the observation
-        # was int32 on Windows and int64 elsewhere and no single declared dtype
-        # could match both.
         obs["image"] = grid.astype(SYMBOLIC_OBS_DTYPE)
 
         return obs

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -333,6 +333,38 @@ def test_symbolic_obs_wrapper(env_id):
     env.close()
 
 
+@pytest.mark.parametrize(
+    "env_id",
+    [
+        "MiniGrid-DistShift1-v0",
+        "MiniGrid-LavaCrossingS11N5-v0",
+        "MiniGrid-FourRooms-v0",
+    ],
+)
+def test_symbolic_obs_wrapper_observation_space(env_id):
+    """The declared space must contain what the wrapper returns.
+
+    The first two channels hold coordinates and reach ``width - 1``, which is
+    above ``max(OBJECT_TO_IDX.values())`` on a large grid; the third holds an
+    object index and is ``-1`` on an empty cell, which is below zero. A single
+    pair of bounds for all three channels was wrong at both ends.
+    """
+    env = SymbolicObsWrapper(gym.make(env_id))
+    image_space = env.observation_space["image"]
+
+    obs, _ = env.reset(seed=123)
+    assert image_space.contains(obs["image"])
+
+    for _ in range(20):
+        obs, _, terminated, truncated, _ = env.step(env.action_space.sample())
+        assert image_space.contains(obs["image"])
+        if terminated or truncated:
+            obs, _ = env.reset(seed=123)
+            assert image_space.contains(obs["image"])
+
+    env.close()
+
+
 @pytest.mark.parametrize("env_id", ["MiniGrid-Empty-16x16-v0"])
 def test_stochastic_action_wrapper(env_id):
     env = gym.make(env_id)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -368,13 +368,7 @@ def test_symbolic_obs_wrapper(env_id):
     ],
 )
 def test_symbolic_obs_wrapper_observation_space(env_id):
-    """The declared space must contain what the wrapper returns.
-
-    The first two channels hold coordinates and reach ``width - 1``, which is
-    above ``max(OBJECT_TO_IDX.values())`` on a large grid; the third holds an
-    object index and is ``-1`` on an empty cell, which is below zero. A single
-    pair of bounds for all three channels was wrong at both ends.
-    """
+    """The declared image space must contain every symbolic observation."""
     env = SymbolicObsWrapper(gym.make(env_id))
     image_space = env.observation_space["image"]
 


### PR DESCRIPTION
## Summary

`SymbolicObsWrapper` declares a single pair of bounds for all three channels:

```python
spaces.Box(low=0, high=max(OBJECT_TO_IDX.values()), shape=(w, h, 3), dtype="uint8")
```

The observation it returns matches none of that, so `observation_space.contains(obs["image"])` is `False` on every environment I tried:

```python
import gymnasium as gym
from minigrid.wrappers import SymbolicObsWrapper

env = SymbolicObsWrapper(gym.make("MiniGrid-FourRooms-v0"))
obs, _ = env.reset(seed=0)
env.observation_space["image"].contains(obs["image"])   # False
```

Three separate mismatches:

| | declared | actual |
|---|---|---|
| lower bound | `0` | the object channel is `-1` on an empty cell |
| upper bound | `10` | the coordinate channels reach `width - 1`: **18** on `FourRooms`, 15 on `Empty-16x16` |
| dtype | `uint8` | `int32` on Windows, `int64` elsewhere |

The upper bound only holds by accident on small grids: the first two channels come from `np.mgrid` and carry the cell's coordinates, so any grid wider than `max(OBJECT_TO_IDX.values()) + 1 = 11` exceeds it.

The dtype is platform-dependent because `np.mgrid` follows NumPy's default integer, so no fixed declaration could have matched both Windows and Linux.

## Changes

* `minigrid/wrappers.py`
  * bounds are now per channel — `0..width-1`, `0..height-1`, `-1..max(OBJECT_TO_IDX.values())`;
  * the observation is cast to a pinned dtype so it is the same on every platform. `int64` is what `np.mgrid` already produced on Linux and macOS, so only Windows changes, and the values involved are small either way.
* `tests/test_wrappers.py` — a test over three grid sizes asserting the declared space contains the observation from `reset()` and from twenty steps, including across an episode boundary.

`DistShift1` (9×7), `LavaCrossingS11N5` (11×11) and `FourRooms` (19×19) are parametrised so both failure modes are covered: the small grids catch the `-1`, and the large one catches the coordinates.

## Verification

`tests/test_wrappers.py`: **2045 passed, 192 skipped**, against 2042 on an unmodified checkout — the three new cases and nothing else moved. The existing `test_symbolic_obs_wrapper` still passes unchanged.

With the fix reverted and the new test kept, all three parametrisations fail, so the test detects the defect rather than passing regardless.

Checked further on `Empty-8x8`, `Empty-16x16` and `MultiRoom-N2-S4` (25×25): every observation from `reset()` and from 60 steps belongs to the declared space.

`black`, `isort --profile black`, `flake8` and `codespell` are clean on both files, using the arguments from `.pre-commit-config.yaml`.
