### PR TITLE
Fix DictObservationSpaceWrapper mission space upper bound

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -465,8 +465,10 @@ class DictObservationSpaceWrapper(ObservationWrapper):
             {
                 "image": env.observation_space["image"],
                 "direction": spaces.Discrete(4),
+                # Word indices are offset by 1 (0 is padding), so the highest
+                # value emitted by `string_to_indices` is len(word_dict)
                 "mission": spaces.MultiDiscrete(
-                    [len(self.word_dict.keys())] * max_words_in_mission
+                    [len(self.word_dict.keys()) + 1] * max_words_in_mission
                 ),
             }
         )

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -146,6 +146,21 @@ def test_dict_observation_space_wrapper(env_spec):
     assert env.string_to_indices(mission) == [
         value for value in obs["mission"] if value != 0
     ]
+    assert env.observation_space.contains(obs)
+    env.close()
+
+
+def test_dict_observation_space_wrapper_mission_space_bounds():
+    """
+    Every word in the vocabulary must encode to a value inside the declared
+    mission space (word indices are offset by 1, with 0 reserved for padding).
+    """
+    env = DictObservationSpaceWrapper(gym.make("MiniGrid-Empty-5x5-v0"))
+    mission_space = env.observation_space["mission"]
+    for word in env.word_dict:
+        indices = env.string_to_indices(word)
+        indices += [0] * (env.max_words_in_mission - len(indices))
+        assert mission_space.contains(indices), word
     env.close()
 
 


### PR DESCRIPTION
# Description

`DictObservationSpaceWrapper.string_to_indices` encodes each word as `word_dict[word] + 1`, with `0` reserved for padding, so the values it emits range over `[0, len(word_dict)]`. The wrapper declared the mission space as `MultiDiscrete([len(word_dict)] * max_words_in_mission)`, which only admits `[0, len(word_dict) - 1]`, leaving the highest-index vocabulary word outside the declared space.

Since #371 that word is `"maze"`, so every WFC environment's mission (`"traverse the maze to get to the goal"`) fails `observation_space.contains(obs)`, and `gymnasium.utils.env_checker.check_env` asserts on `reset()`:

```python
import gymnasium as gym
from minigrid.wrappers import DictObservationSpaceWrapper

env = DictObservationSpaceWrapper(gym.make("MiniGrid-WFC-MazeSimple-v0"))
obs, _ = env.reset(seed=0)
obs["mission"][:8]                           # [29, 31, 51, 38, 20, 38, 31, 15]
env.observation_space["mission"].nvec[0]     # 51  -> admits 0..50
env.observation_space.contains(obs)          # False
```

Libraries that size one-hot/embedding tables from `nvec` (e.g. SB3's `preprocess_obs`) raise on the value `51`.

This PR declares `len(word_dict) + 1` values per slot (the encoding itself is unchanged), asserts `observation_space.contains(obs)` in the existing parametrized wrapper test, and adds a test that every vocabulary word encodes into the declared space. Both fail on `main` and pass here; `tests/test_wrappers.py`: 2043 passed, 192 skipped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
