### PR TITLE
test: make BabyAI bot failures visible across fixed seeds

### DIFF
--- a/tests/test_baby_ai_bot.py
+++ b/tests/test_baby_ai_bot.py
@@ -22,7 +22,8 @@ for k_i in gym.envs.registry.keys():
 
 
 @pytest.mark.parametrize("env_id", babyai_envs)
-def test_bot(env_id):
+@pytest.mark.parametrize("seed", range(5))
+def test_bot(env_id, seed):
     """
     The BabyAI Bot should be able to solve all BabyAI environments,
     allowing us therefore to generate demonstrations.
@@ -31,28 +32,26 @@ def test_bot(env_id):
     env = gym.make(env_id)
     # env = gym.make(env_id, render_mode="human") # for visual debugging
 
-    # reset env
-    curr_seed = 0
-
-    num_steps = 240
-    terminated = False
-    while not terminated:
-        env.reset(seed=curr_seed)
+    try:
+        env.reset(seed=seed)
 
         # create expert bot
         expert = BabyAIBot(env)
 
         last_action = None
-        for _step in range(num_steps):
+        for _step in range(env.unwrapped.max_steps):
             action = expert.replan(last_action)
             obs, reward, terminated, truncated, info = env.step(action)
             last_action = action
             env.render()
 
-            if terminated:
+            if terminated or truncated:
+                assert terminated and reward > 0, (
+                    f"Bot did not solve the mission: reward={reward}, "
+                    f"terminated={terminated}, truncated={truncated}"
+                )
                 break
-
-        # try again with a different seed
-        curr_seed += 1
-
-    env.close()
+        else:
+            pytest.fail("Bot exhausted the episode step budget")
+    finally:
+        env.close()


### PR DESCRIPTION
## Summary

Addresses #475. **Draft: the corrected assertions expose existing mission failures; this is not a green/merge-ready test change.**

The current test retries new seeds until an episode terminates and never checks the reward. In BabyAI, termination can also mean mission failure, so that path can pass with reward zero.

Changes only `tests/test_baby_ai_bot.py`:

- Parameterize five fixed seeds (0–4), reporting each environment/seed separately instead of retrying until termination.
- Use the environment's post-reset episode step budget instead of an unrelated 240-step cap.
- Stop on termination or truncation and require successful termination with positive reward.
- Fail on budget exhaustion and always close the environment, including assertion/exception paths.

No environment, bot, or verifier behavior is changed. No newly failing environment is skipped or xfailed.

## Validation and newly exposed failures

The original `test_bot("BabyAI-OpenDoorsOrderN4Debug-v0")` passes on main. The revised test at seed 0 fails with `reward=0, terminated=True, truncated=False`.

Focused real-environment run over the two debug variants: **6 failed, 4 passed**.

| Environment | Failing seeds |
| --- | --- |
| `BabyAI-OpenDoorsOrderN2Debug-v0` | 1, 3 |
| `BabyAI-OpenDoorsOrderN4Debug-v0` | 0, 1, 2, 4 |

All six fail the positive-reward assertion. These are not dependency/setup failures.

```bash
PYTHONPATH=. SDL_VIDEODRIVER=dummy \
uv run --no-project --python 3.13 --with numpy --with gymnasium \
  --with pygame-ce --with pytest -- python -m pytest tests/test_baby_ai_bot.py \
  -k 'OpenDoorsOrderN2Debug or OpenDoorsOrderN4Debug' -q --tb=short
```

A broader run collected 460 cases and reached over 93% progress, but did not finish within the local lightweight validation window; I stopped it after roughly three minutes, so there is **no full-suite pass claim**. The episode step bound does not impose a wall-clock timeout on reset or bot planning.

Black 24.10.0, isort 5.13.2, flake8 7.1.1 (project hook settings), and `git diff --check` pass.

## Before merging

The debug mission failures need resolution or an explicit maintainer decision on how to track them. A possible interaction worth examining is `BeforeInstr`/`AfterInstr` rechecking the same action against the next instruction after the first succeeds, while these environments construct strict `OpenInstr` children. This is a code-inspection hypothesis, not a verified fix; I have kept changes to that behavior out of this test-only PR.

AI assistance: implementation and local testing with OpenAI Codex.
