### PR TITLE
Draw the substituted action from the env RNG, over the whole action space

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -808,11 +808,11 @@ class StochasticActionWrapper(ActionWrapper):
 
     def action(self, action):
         """ """
-        if np.random.uniform() < self.prob:
+        if self.np_random.random() < self.prob:
             return action
         else:
             if self.random_action is None:
-                return self.np_random.integers(0, high=6)
+                return self.np_random.integers(self.env.action_space.n)
             else:
                 return self.random_action
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -433,6 +433,29 @@ def test_stochastic_action_wrapper(env_id):
     env.close()
 
 
+@pytest.mark.parametrize("env_id", ["MiniGrid-Empty-16x16-v0"])
+def test_stochastic_action_wrapper_follows_the_env_seed(env_id):
+    def sample_actions(global_seed):
+        np.random.seed(global_seed)
+        env = StochasticActionWrapper(gym.make(env_id), prob=0.5)
+        env.reset(seed=1)
+        actions = [int(env.action(Actions.left)) for _ in range(50)]
+        env.close()
+        return actions
+
+    assert sample_actions(0) == sample_actions(1)
+
+
+@pytest.mark.parametrize("env_id", ["MiniGrid-Empty-16x16-v0"])
+def test_stochastic_action_wrapper_can_sample_every_action(env_id):
+    env = StochasticActionWrapper(gym.make(env_id), prob=0.0)
+    env.reset(seed=1)
+    sampled = {int(env.action(Actions.left)) for _ in range(1000)}
+    env.close()
+
+    assert sampled == set(range(env.action_space.n))
+
+
 def test_dict_observation_space_doesnt_clash_with_one_hot():
     env = gym.make("MiniGrid-Empty-5x5-v0")
     env = OneHotPartialObsWrapper(env)


### PR DESCRIPTION
## Summary

`StochasticActionWrapper` replaces the agent's action with a random one. Two things about that randomness are wrong.

**The coin flip does not follow the seed.** The substitute action is drawn from `self.np_random`, but the flip that decides whether to substitute is drawn from the global NumPy RNG:

```python
if np.random.uniform() < self.prob:                  # global RNG
    return action
else:
    if self.random_action is None:
        return self.np_random.integers(0, high=6)    # env RNG
```

So `reset(seed=...)` does not reproduce a rollout, and `np.random.seed` anywhere else in the process changes it:

```python
import numpy as np
import gymnasium as gym
from minigrid.wrappers import StochasticActionWrapper

def actions(global_seed):
    np.random.seed(global_seed)
    env = StochasticActionWrapper(gym.make("MiniGrid-Empty-16x16-v0"), prob=0.5)
    env.reset(seed=1)
    return [int(env.action(0)) for _ in range(10)]
```

| `np.random.seed` | actions after `reset(seed=1)` |
|---|---|
| 0 | `[2, 3, 4, 5, 0, 0, 0, 0, 4, 0]` |
| 1 | `[0, 2, 0, 0, 0, 0, 0, 0, 0, 3]` |
| 2 | `[0, 0, 2, 0, 0, 0, 0, 3, 0, 0]` |

It is also the only draw from the process-wide NumPy stream in the package: `grep -rn "np\.random\." minigrid/` otherwise returns type annotations and explicitly constructed generators in `envs/wfc`.

**`done` is never sampled.** The action space is `Discrete(len(Actions))` — that is `Discrete(7)`, and `Actions.done == 6`. `integers(0, high=6)` stops at 5, so the docstring's "a random action is sampled from the action space" holds for six actions out of seven. Counts over 70 000 substitutions on `Empty-16x16` with `prob=0.0`:

| | left | right | forward | pickup | drop | toggle | done |
|---|---|---|---|---|---|---|---|
| before | 11762 | 11610 | 11804 | 11696 | 11612 | 11516 | **0** |
| after | 10129 | 10011 | 10028 | 10004 | 9909 | 10037 | 9882 |

## Changes

* `minigrid/wrappers.py` — two lines in `StochasticActionWrapper.action`:
  * the coin flip moves to `self.np_random`, the generator the substitute action already came from;
  * the bound becomes `self.env.action_space.n` instead of the literal `6`. `self.env` and not `self`, because `ActionWrapper.action` returns an action for the wrapped environment.
* `tests/test_wrappers.py` — two cases:
  * `test_stochastic_action_wrapper_follows_the_env_seed` — one `reset(seed=1)`, two different global NumPy seeds, same sequence of actions;
  * `test_stochastic_action_wrapper_can_sample_every_action` — with `prob=0.0`, every action in `range(action_space.n)` appears within 1000 substitutions.

## Verification

`tests/test_wrappers.py`: **2051 passed, 192 skipped**. The existing `test_stochastic_action_wrapper` passes unchanged.

With the fix reverted and the new tests kept, both fail — the seed test on the first action, the coverage test on the missing `6`. The test detects the defect rather than passing regardless.

`black`, `isort --profile black`, `flake8` and `codespell` are clean on both files, using the arguments from `.pre-commit-config.yaml`.
