### PR TITLE
Declare a mission space that holds the whole vocabulary

### DIFF
--- a/minigrid/wrappers.py
+++ b/minigrid/wrappers.py
@@ -467,7 +467,7 @@ class DictObservationSpaceWrapper(ObservationWrapper):
                 "image": env.observation_space["image"],
                 "direction": spaces.Discrete(4),
                 "mission": spaces.MultiDiscrete(
-                    [len(self.word_dict.keys())] * max_words_in_mission
+                    [len(self.word_dict) + 1] * max_words_in_mission
                 ),
             }
         )

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -177,6 +177,20 @@ def test_dict_observation_space_wrapper(env_spec):
     assert env.string_to_indices(mission) == [
         value for value in obs["mission"] if value != 0
     ]
+    assert env.observation_space.contains(obs)
+    env.close()
+
+
+def test_dict_observation_space_covers_the_whole_vocabulary():
+    words = DictObservationSpaceWrapper.get_minigrid_words()
+    env = DictObservationSpaceWrapper(
+        gym.make("MiniGrid-Empty-5x5-v0"), max_words_in_mission=len(words) + 1
+    )
+    indices = env.string_to_indices(" ".join(words))
+    padded = indices + [0] * (env.max_words_in_mission - len(indices))
+
+    assert env.observation_space["mission"].contains(np.array(padded))
+
     env.close()
 
 


### PR DESCRIPTION
## Summary

`DictObservationSpaceWrapper` encodes the mission as word indices and declares them as

```python
spaces.MultiDiscrete([len(self.word_dict.keys())] * max_words_in_mission)
```

The vocabulary holds 51 words, so the declared space accepts `0..50`. But `string_to_indices` shifts every index by one, because `0` is the padding value:

```python
indices.append(self.word_dict[word] + offset)   # offset=1
```

The encoded values therefore run `1..51`. The last word of the vocabulary, `maze` at index 50, encodes to 51 — one past the declared bound:

```python
import gymnasium as gym
from minigrid.wrappers import DictObservationSpaceWrapper

env = DictObservationSpaceWrapper(gym.make("MiniGrid-WFC-MazeSimple-v0"))
obs, _ = env.reset(seed=0)

env.unwrapped.mission                      # 'traverse the maze to get to the goal'
obs["mission"][:8]                         # [29, 31, 51, 38, 20, 38, 31, 15]
env.observation_space["mission"].nvec[0]   # 51
env.observation_space.contains(obs)        # False
```

All six registered WFC environments carry that mission — `MazeSimple`, `DungeonMazeScaled`, `RoomsFabric`, `ObstaclesBlackdots`, `ObstaclesAngular`, `ObstaclesHogs3` — so `contains` is `False` on every one of them. The other 148 environments this wrapper supports pass today because their missions happen to use words earlier in the list, not because the bound is right.

## Changes

* `minigrid/wrappers.py` — the bound becomes `len(self.word_dict) + 1`: one value per word, plus the `0` the padding uses. Encoded observations are unchanged; only the space that declares them moves.
* `tests/test_wrappers.py`
  * `test_dict_observation_space_wrapper` gains `assert env.observation_space.contains(obs)`. It is parametrised over every non-BabyAI environment spec, WFC included, so all six failing environments are covered.
  * `test_dict_observation_space_covers_the_whole_vocabulary` encodes every word of the vocabulary at once and asserts the declared space accepts the result. It needs no WFC dependency, so it also runs on installs without `networkx` and `imageio`.

## Verification

`tests/test_wrappers.py`: **2050 passed, 192 skipped**, against 2049 on an unmodified checkout — the one new case and nothing else moved.

With the fix reverted and the tests kept, `-k dict_observation_space` gives **7 failed, 77 passed**: the six WFC parametrisations and the vocabulary test. The tests detect the defect rather than passing regardless.

`pytest --doctest-modules minigrid/wrappers.py`: **14 passed**. The doctest for this wrapper prints encoded mission values, and those do not change.

`black`, `isort --profile black`, `flake8` and `codespell` are clean on both files, using the arguments from `.pre-commit-config.yaml`.
